### PR TITLE
docs(readme): simplify wiki setup, defer to wiki-setup skill; remove …

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,92 +37,31 @@ Ship a production-grade coding harness where the agent:
 
 ## Obsidian wiki setup
 
-The wiki lives in the [GitHub wiki repo](https://github.com/aryaniyaps/ultimate-pi.wiki.git) and is checked out locally at `~/wiki/ultimate-pi`. Most wiki skills need this vault configured. One-time setup:
+The wiki lives in your repo's GitHub wiki and is checked out locally. Most wiki skills need this vault configured. One-time setup:
+
+> **For forks:** replace `aryaniyaps/ultimate-pi` with your own `<owner>/<repo>` throughout.
 
 ### Step 1 — Activate the GitHub wiki
 
 The repo must have at least one page before you can clone it:
 
-1. Go to `https://github.com/aryaniyaps/ultimate-pi/wiki`
+1. Go to `https://github.com/<owner>/<repo>/wiki` (e.g. `https://github.com/aryaniyaps/ultimate-pi/wiki`)
 2. Click **Create the first page** (or **New Page** if it already exists)
 3. Save any content — this activates the wiki git endpoint
 
-### Step 2 — Clone and initialize the vault
+### Step 2 — Clone the wiki repo
 
 ```bash
-git clone https://github.com/aryaniyaps/ultimate-pi.wiki.git ~/wiki/ultimate-pi
-cd ~/wiki/ultimate-pi
-
-# Create folder structure
-mkdir -p {concepts,entities,skills,references,synthesis,journal,projects,_archives,_raw,.obsidian}
+git clone https://github.com/<owner>/<repo>.wiki.git ~/wiki/<repo>
 ```
 
-This creates the folder layout wiki skills expect:
-- `concepts/` `entities/` `skills/` `references/` `synthesis/` `journal/` — topic folders
-- `projects/` — per-project knowledge
-- `_archives/` — wiki snapshots for rebuild/restore
-- `_raw/` — staging area; drop drafts here, `wiki-ingest` promotes them
+### Step 3 — Configure `.env`
 
-### Step 3 — Create special files
-
-The vault root needs three files. `wiki-setup` auto-generates them, or create manually:
-
-**Home.md** — top-level wiki index (must be `Home.md` for GitHub wiki)
-
-```markdown
----
-title: Wiki Index
----
-
-# Wiki Index
-
-*This index is automatically maintained. Last updated: 2026-04-28*
-
-## Concepts
-
-*No pages yet. Use `wiki-ingest` to add your first source.*
-
-## Entities
-
-## Skills
-
-## References
-
-## Synthesis
-
-## Journal
-```
-
-**log.md** — append-only changelog
-
-**hot.md** — semantic cache of recent activity (~500 words)
-
-### Step 4 — Create `.gitignore`
-
-```bash
-cat > .gitignore << 'EOF'
-.obsidian/
-_raw/
-_archives/
-.DS_Store
-EOF
-```
-
-### Step 5 — Commit and push
-
-```bash
-git add -A
-git commit -m "init: obsidian wiki vault structure"
-git push
-```
-
-### Step 6 — Configure `.env` in your project
-
-In your project root, create `.env`:
+In your project root, create `.env` pointing to the vault:
 
 ```bash
 # Required: absolute path to your Obsidian vault
-OBSIDIAN_VAULT_PATH=~/wiki/ultimate-pi
+OBSIDIAN_VAULT_PATH=~/wiki/<repo>
 
 # Optional: source directories to ingest from (comma-separated)
 OBSIDIAN_SOURCES_DIR=~/Documents
@@ -132,9 +71,19 @@ OBSIDIAN_SOURCES_DIR=~/Documents
 # QMD_PAPERS_COLLECTION=
 ```
 
-### Step 7 — Open in Obsidian
+### Step 4 — Run `wiki-setup`
 
-1. Open Obsidian → **File → Open Vault** → select `~/wiki/ultimate-pi`
+Inside your PI session, run:
+
+```
+/wiki-setup
+```
+
+This skill walks you through the rest automatically — creating the folder structure, special files (`Home.md`, `log.md`, `hot.md`), `.gitignore`, and `.obsidian` config. It stays in sync with the skill definition, so you always get the latest structure without manually mirroring docs here.
+
+### Step 5 — Open in Obsidian
+
+1. Open Obsidian → **File → Open Vault** → select your vault directory (e.g. `~/wiki/ultimate-pi`)
 2. Install recommended community plugins:
    - **Dataview** — query page metadata, dynamic tables
    - **Graph Analysis** — enhanced graph view

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -6,18 +6,6 @@
       "sourceType": "github",
       "computedHash": "a818cdc41dcfaa50dd891c5cb5e5705968338de02e7e37949ca56e8c30ad4176"
     },
-    "claude-history-ingest": {
-      "source": "Ar9av/obsidian-wiki",
-      "sourceType": "github",
-      "skillPath": ".skills/claude-history-ingest/SKILL.md",
-      "computedHash": "06aea9356b6e09908c8eef8e70660c0393b6ef170c73d9972e2e1396c49e172e"
-    },
-    "codex-history-ingest": {
-      "source": "Ar9av/obsidian-wiki",
-      "sourceType": "github",
-      "skillPath": ".skills/codex-history-ingest/SKILL.md",
-      "computedHash": "6a8c55166495c89e608dff26be4ac7f1e8ade37fff09491f902575587332dcc8"
-    },
     "compress": {
       "source": "juliusbrussee/caveman",
       "sourceType": "github",
@@ -56,12 +44,6 @@
       "sourceType": "github",
       "skillPath": ".skills/graph-colorize/SKILL.md",
       "computedHash": "ac78796031062b02150dd1244a21b7b66b6aabf7a20f7701e99d852a53373e3c"
-    },
-    "hermes-history-ingest": {
-      "source": "Ar9av/obsidian-wiki",
-      "sourceType": "github",
-      "skillPath": ".skills/hermes-history-ingest/SKILL.md",
-      "computedHash": "1fcbf41071d36f0a364ce161eb07f0411ff4f9226dd4fb3f7007c33940b3574a"
     },
     "ingest-url": {
       "source": "Ar9av/obsidian-wiki",
@@ -104,18 +86,6 @@
       "skillPath": "skills/obsidian-markdown/SKILL.md",
       "computedHash": "cacc9058a35ad3fd4985b4c31121bff8202f1337c39808c1326ded6a19a7915f"
     },
-    "openclaw-history-ingest": {
-      "source": "Ar9av/obsidian-wiki",
-      "sourceType": "github",
-      "skillPath": ".skills/openclaw-history-ingest/SKILL.md",
-      "computedHash": "943ac773bb35eba06ee975f592e5d6f32de6b711cf91fc5b43d0e943f25e0d90"
-    },
-    "save": {
-      "source": "AgriciDaniel/claude-obsidian",
-      "sourceType": "github",
-      "skillPath": "skills/skills/save",
-      "computedHash": "installed-manually"
-    },
     "scrapling-official": {
       "source": "D4Vinci/Scrapling",
       "sourceType": "github",
@@ -156,12 +126,6 @@
       "sourceType": "github",
       "skillPath": ".skills/wiki-export/SKILL.md",
       "computedHash": "4b26018ff2ba71290c52e42ade0bcd8fe9bc08ea2ffa8a15bbf2200bcdf0e1f1"
-    },
-    "wiki-history-ingest": {
-      "source": "Ar9av/obsidian-wiki",
-      "sourceType": "github",
-      "skillPath": ".skills/wiki-history-ingest/SKILL.md",
-      "computedHash": "f478e4a1bd78db091ac26aa8ccf17b923e30f2483a11e83f6637f02487d0fa0e"
     },
     "wiki-ingest": {
       "source": "Ar9av/obsidian-wiki",


### PR DESCRIPTION
…stale entries from skills-lock

- Collapse 7-step manual wiki setup into 5 steps, deferring vault init to /wiki-setup skill
- Use generic <owner>/<repo> placeholders for fork contributors
- Remove claude-history-ingest, codex-history-ingest, hermes-history-ingest, openclaw-history-ingest, wiki-history-ingest, and save from skills-lock.json