### PR TITLE
chore(skills): remove stale .claude/skills symlinks

### DIFF
--- a/.claude/skills/autoresearch
+++ b/.claude/skills/autoresearch
@@ -1,1 +1,0 @@
-../../.agents/skills/autoresearch

--- a/.claude/skills/canvas
+++ b/.claude/skills/canvas
@@ -1,1 +1,0 @@
-../../.agents/skills/canvas

--- a/.claude/skills/defuddle
+++ b/.claude/skills/defuddle
@@ -1,1 +1,0 @@
-../../.agents/skills/defuddle

--- a/.claude/skills/obsidian-bases
+++ b/.claude/skills/obsidian-bases
@@ -1,1 +1,0 @@
-../../.agents/skills/obsidian-bases

--- a/.claude/skills/obsidian-markdown
+++ b/.claude/skills/obsidian-markdown
@@ -1,1 +1,0 @@
-../../.agents/skills/obsidian-markdown

--- a/.claude/skills/save
+++ b/.claude/skills/save
@@ -1,1 +1,0 @@
-../../.agents/skills/save

--- a/.claude/skills/wiki
+++ b/.claude/skills/wiki
@@ -1,1 +1,0 @@
-../../.agents/skills/wiki

--- a/.claude/skills/wiki-fold
+++ b/.claude/skills/wiki-fold
@@ -1,1 +1,0 @@
-../../.agents/skills/wiki-fold

--- a/.claude/skills/wiki-ingest
+++ b/.claude/skills/wiki-ingest
@@ -1,1 +1,0 @@
-../../.agents/skills/wiki-ingest

--- a/.claude/skills/wiki-lint
+++ b/.claude/skills/wiki-lint
@@ -1,1 +1,0 @@
-../../.agents/skills/wiki-lint

--- a/.claude/skills/wiki-query
+++ b/.claude/skills/wiki-query
@@ -1,1 +1,0 @@
-../../.agents/skills/wiki-query


### PR DESCRIPTION
- Removed 11 broken symlinks from .claude/skills/ directory
- Symlinks pointed to ../../.agents/skills/ which no longer resolve
- Skills now managed via .pi/skills/ instead