### PR TITLE
feat: ADR-010 harness-wiki tight-coupling contract

### DIFF
--- a/wiki/decisions/adr-010.md
+++ b/wiki/decisions/adr-010.md
@@ -1,0 +1,55 @@
+---
+type: decision
+title: "ADR-010: Agentic Harness ↔ Wiki Tight-Coupling Contract"
+status: active
+priority: 1
+created: "2026-04-28"
+updated: "2026-04-28"
+tags: [decision, harness, wiki, integration, pipeline, adr]
+sources:
+  - "[[harness]]"
+  - "[[harness-implementation-plan]]"
+  - "[[adr-009]]"
+  - "[[adr-008]]"
+  - "[[persistent-memory]]"
+  - "[[wiki-query-interface]]"
+related:
+  - "[[colocate-wiki]]"
+  - "[[harness-wiki-skill-mapping]]"
+  - "[[harness-wiki-pipeline]]"
+---
+
+# ADR-010: Agentic Harness ↔ Wiki Tight-Coupling Contract
+
+## Context
+
+The harness has 8 layers. Layers 6 (Persistent Memory) and 8 (Wiki Query Interface) already reference the wiki. But the other 6 layers have **no explicit read/write contract** with the wiki. This creates two failure modes:
+
+1. **Design drift**: An agent makes a decision that contradicts an existing ADR or module spec because it never read the wiki first.
+2. **Wiki staleness**: After a pipeline event changes the codebase, the wiki is not updated — decisions, patterns, and statuses go stale.
+
+[[adr-009]] replaced Vectra with LLM-native wiki search. [[colocate-wiki]] put the wiki in-repo. Now we need the **contract** that makes the harness and wiki a single synchronized system.
+
+## Decision
+
+**Every harness layer reads relevant wiki docs before acting, and writes back to the wiki after every state transition.** The contract is enforced at the extension layer (L7 schema orchestration), not by convention.
+
+Two axioms:
+1. **Read-first**: No layer acts without querying the wiki for relevant ADRs, module specs, and patterns.
+2. **Write-after**: No state transition completes without a wiki write that keeps docs current.
+
+## Rationale
+
+- **Consistency**: If ADR-008 says "black-box QA", no layer should generate implementation-coupled tests. Reading the wiki first prevents this.
+- **Traceability**: Every state transition produces a wiki artifact. Future sessions can reconstruct the full decision chain.
+- **Staleness elimination**: The wiki is the single source of truth for design decisions. If code changes, the wiki reflects it. If the wiki says something, the code respects it.
+- **Self-healing**: wiki-lint after every 10-15 writes catches contradictions, orphans, and stale claims before they compound.
+
+## Consequences
+
+- **Positive**: Harness decisions are always grounded in documented architecture.
+- **Positive**: Wiki stays current automatically — no manual doc updates needed.
+- **Positive**: New sessions can pick up exactly where the last left off via hot.md.
+- **Negative**: Extra token cost per subtask (~500-1500 for reads, ~500-1500 for writes).
+- **Negative**: Requires discipline at the extension-layer hooks — must not skip wiki reads.
+- **Negative**: Lint runs add latency but prevent long-term decay.

--- a/wiki/flows/harness-wiki-pipeline.md
+++ b/wiki/flows/harness-wiki-pipeline.md
@@ -1,0 +1,204 @@
+---
+type: flow
+title: Harness-Wiki Pipeline
+status: active
+created: "2026-04-28"
+updated: "2026-04-28"
+tags: [flow, harness, wiki, pipeline, integration, read-first, write-after]
+sources:
+  - "[[adr-010]]"
+  - "[[harness-wiki-skill-mapping]]"
+related:
+  - "[[harness]]"
+  - "[[persistent-memory]]"
+  - "[[wiki-query-interface]]"
+  - "[[schema-orchestration]]"
+---
+
+# Harness-Wiki Pipeline
+
+The exact data flow between the harness pipeline and the wiki vault. Implements [[adr-010]]: read-first, write-after, no-staleness.
+
+## Core Contract
+
+```
+┌─────────────────────────────────────────────────┐
+│              HARNESS LAYER ACTION                 │
+│                                                   │
+│   ┌──────────┐    ┌──────────┐    ┌──────────┐   │
+│   │ READ WIKI │ →  │  LAYER   │ →  │ WRITE    │   │
+│   │ (query)   │    │  LOGIC   │    │ WIKI     │   │
+│   └──────────┘    └──────────┘    └──────────┘   │
+│         ↑                              ↓         │
+│    ADRs, specs,              Decisions, patterns, │
+│    patterns, status           events, statuses   │
+└─────────────────────────────────────────────────┘
+```
+
+**Invariant**: No layer acts without reading. No layer completes without writing.
+
+## Read-First Protocol
+
+Before any layer executes, the following wiki reads happen:
+
+### Session Bootstrap (once per session)
+
+| Step | Skill | Target | Purpose |
+|------|-------|--------|---------|
+| 1 | `wiki-query` quick | `hot.md` | Load recent context (~500 tokens) |
+| 2 | `wiki-query` quick | `index.md` | Know what pages exist (~1000 tokens) |
+| 3 | `wiki-query` standard | ADRs in `decisions/` | Load active constraints |
+| 4 | `compress` | If hot.md > 600 words | Trim to stay under token budget |
+
+### Per-Layer Read
+
+| Layer | Mandatory Wiki Reads | Skill | Depth |
+|-------|---------------------|-------|-------|
+| L1 | `decisions/adr-008`, `modules/spec-hardening`, any existing spec for feature | `wiki-query` standard | Standard |
+| L2 | `flows/plan-*`, `modules/structured-planning`, all ADRs from L1 | `wiki-query` deep | Deep |
+| L3 | `hot.md` (current checkpoint state), `flows/plan-{feature}` | `wiki-query` quick | Quick |
+| L4 | `decisions/adr-008`, `modules/adversarial-verification`, L1 spec | `wiki-query` standard | Standard |
+| L5 | `modules/automated-observability`, L1 spec | `wiki-query` standard | Standard |
+| L6 | Per depth table in [[persistent-memory]] | `wiki-query` | Variable |
+| L7 | `modules/schema-orchestration`, `flows/plan-*` | `wiki-query` standard | Standard |
+| L8 | Per depth table in [[wiki-query-interface]] | `wiki-query` | Variable |
+
+**Failure mode**: If `wiki-query` returns no relevant ADR for a layer that requires one, the layer MUST halt and request the user create the missing ADR before proceeding.
+
+## Write-After Protocol
+
+After every state transition, the following wiki writes happen:
+
+### Per-Layer Write Matrix
+
+| Layer | Event | Wiki Write | Skill | Target Page |
+|-------|-------|-----------|-------|-------------|
+| L1 | Spec hardened | Decision + callout | `save` | `decisions/spec-{feature}.md` |
+| L1 | Ambiguity resolved | Decision | `save` | `decisions/spec-{feature}.md` |
+| L2 | Plan approved | Flow page | `save` | `flows/plan-{feature}.md` |
+| L2 | Plan rejected | Failure pattern | `save` | `modules/{feature}.md` with `> [!contradiction]` |
+| L3 | Checkpoint passed | Log entry + hot.md | `wiki-ingest` + `save` | `log.md` + `hot.md` |
+| L3 | Drift detected | Failure pattern | `save` | `modules/{feature}.md` with `> [!contradiction]` |
+| L4 | Subtask verified | Success pattern | `save` | `modules/{feature}.md` with `status: mature` |
+| L4 | Subtask failed | Failure pattern | `save` | `modules/{feature}.md` with `> [!contradiction]` |
+| L4 | QA test results | Decision + metrics | `save` | `decisions/qa-{feature}.md` |
+| L5 | Observability defined | Decision | `save` | `decisions/observability-{feature}.md` |
+| L5 | Metric verified | Module update | `wiki-ingest` | `modules/automated-observability.md` |
+| L6 | Memory write | Per event hooks table | `save` / `wiki-ingest` | Per [[persistent-memory]] mapping |
+| L7 | Wave completed | Orchestration status | `wiki-ingest` | `modules/schema-orchestration.md` |
+| L7 | Replan triggered | Log entry + flow update | `wiki-ingest` | `log.md` + `flows/plan-{feature}.md` |
+| L8 | Deep query answered | Synthesis page | `save` | `questions/research-{topic}.md` |
+
+### Session Shutdown (once per session)
+
+| Step | Skill | Target | Purpose |
+|------|-------|--------|---------|
+| 1 | `save` | `hot.md` | Update recent context for next session |
+| 2 | `wiki-ingest` | `log.md` | Append shutdown entry |
+| 3 | `wiki-lint` | Full vault | Catch staleness, orphans, dead links |
+| 4 | `wiki-fold` | `wiki/folds/` | If 8+ entries since last fold, run fold |
+
+## Staleness Elimination Rules
+
+These rules guarantee no wiki page goes stale:
+
+### Rule 1: Status Propagation
+When a module's implementation status changes (e.g., `status: developing` → `status: active`), the module page frontmatter MUST be updated in the same pipeline step.
+
+### Rule 2: Decision Referencing
+When a new ADR supersedes or modifies an existing one:
+- The new ADR MUST have `supersedes: [[old-adr]]` in frontmatter
+- The old ADR MUST have `superseded_by: [[new-adr]]` and `status: superseded` updated
+- `index.md` MUST reflect the change
+
+### Rule 3: Cross-Reference Integrity
+When `save` creates a new page, it MUST:
+- Add wikilinks to all related pages mentioned in frontmatter
+- Add a backlink entry in each referenced page (or flag for `wiki-lint` to catch)
+- Update `index.md` with the new entry
+
+### Rule 4: Contradiction Resolution
+When `wiki-lint` detects a contradiction between pages:
+- Both pages get `> [!contradiction]` callouts
+- A `questions/contradiction-{topic}.md` page is created
+- The next L7 orchestration step MUST resolve it before proceeding
+
+### Rule 5: Hot Cache Freshness
+`hot.md` is overwritten completely at:
+- Session start (read from wiki state)
+- Every L3 checkpoint (update with current state)
+- Session shutdown (write final state)
+
+Hot.md MUST never be older than the last completed L3 checkpoint.
+
+### Rule 6: Lint Schedule
+`wiki-lint` runs:
+- After every 10-15 wiki writes (counter tracked by L7)
+- At session shutdown
+- On explicit user request
+
+Lint output goes to `wiki/meta/lint-report-YYYY-MM-DD.md`.
+
+### Rule 7: Index Synchronization
+`index.md` is updated:
+- After every `save` that creates a new page
+- After every `wiki-ingest` batch
+- After every `wiki-lint` that removes or merges pages
+- Never manually — always through skills
+
+## Extension Hook Implementation
+
+Each `extensions/harness-*.ts` file implements this pattern:
+
+```typescript
+// Pre-action: read wiki
+const wikiContext = await wikiQuery({
+  depth: 'standard',
+  targets: ['decisions/', `modules/${layerName}`],
+});
+
+// Validate: ensure we have the ADRs we need
+if (requiredADRs.some(adr => !wikiContext.hasADR(adr))) {
+  throw new HarnessError('MISSING_ADR', 'Required ADR not found in wiki');
+}
+
+// Execute: layer logic
+const result = await layerLogic(input, wikiContext);
+
+// Post-action: write wiki
+await save({
+  type: result.writeType,
+  title: result.writeTitle,
+  content: result.writeContent,
+  related: result.relatedPages,
+});
+
+// Update: hot cache if significant
+if (result.affectsHotCache) {
+  await updateHotCache(result);
+}
+
+// Increment: write counter for lint scheduling
+writeCounter++;
+if (writeCounter >= 10) {
+  await wikiLint();
+  writeCounter = 0;
+}
+```
+
+## Token Budget Impact
+
+| Activity | Tokens | Frequency |
+|----------|--------|-----------|
+| Session bootstrap reads | ~3,000 | 1/session |
+| Per-layer reads | ~500-3,000 | Per subtask x layers |
+| Per-layer writes | ~500-1,500 | Per subtask x events |
+| Lint runs | ~2,000 | Every 10-15 writes |
+| Hot cache updates | ~500 | Per checkpoint |
+| Fold runs | ~1,000 | After 8+ log entries |
+| **Added per subtask** | **~3,000-6,000** | On top of existing ~17,500 |
+
+New total per subtask: **~20,500-23,500 tokens**.
+New total for 5-subtask plan: **~102,500-117,500 tokens** overhead.
+
+This is a ~20-35% increase over the pre-integration budget, but eliminates the risk of design drift and wiki staleness entirely.

--- a/wiki/hot.md
+++ b/wiki/hot.md
@@ -1,25 +1,27 @@
 ---
 type: meta
 title: "Hot Cache"
-updated: 2026-04-28T00:00:00
+updated: 2026-04-28T20:50:00
 ---
 
 # Recent Context
 
 ## Last Updated
-2026-04-28. Full ingest of GitHub wiki source (13 pages from `.raw/ultimate-pi.wiki/`).
+2026-04-28. Harness-wiki integration contract established.
 
 ## Key Recent Facts
-- Ingested all 8 harness layer concept pages + harness implementation plan
-- Created [[adr-008]] (Black-Box QA) and [[adr-009]] (claude-obsidian Mode B) as decision pages
-- Updated [[harness]] module page with cross-links to all 8 layer pages
-- The harness pipeline is **always-on** — layers cannot be disabled, only tuned
-- QA tests are generated from spec ONLY (ADR-008) — prevents gaming
-- Memory layer uses claude-obsidian skills (ADR-009) instead of Vectra — eliminates ~87MB deps
+- ADR-010: Every harness layer MUST read wiki before acting, write wiki after every state transition
+- 11 Obsidian skills mapped to pipeline stages: wiki-query (read), save/wiki-ingest (write), wiki-lint (periodic), wiki-fold (periodic), obsidian-markdown (format), obsidian-bases (dashboards), canvas (visual), autoresearch (research), compress (token savings), defuddle (pre-process)
+- 7 staleness elimination rules: status propagation, decision referencing, cross-ref integrity, contradiction resolution, hot cache freshness, lint schedule, index sync
+- L7 schema orchestration is the enforcement chokepoint: blocks any layer that skips wiki reads
+- Token budget impact: ~20-35% increase, from ~17,500 to ~20,500-23,500 per subtask
+- Failure mode: if wiki-query returns no relevant ADR, layer halts until missing ADR is created
 
 ## Recent Changes
-- Created: [[spec-hardening]], [[structured-planning]], [[grounding-checkpoints]], [[adversarial-verification]], [[automated-observability]], [[persistent-memory]], [[schema-orchestration]], [[wiki-query-interface]], [[harness-implementation-plan]], [[adr-008]], [[adr-009]]
-- Updated: [[harness]], [[index]]
+- Created: [[adr-010]], [[harness-wiki-skill-mapping]], [[harness-wiki-pipeline]]
+- Updated: [[index]] (added 3 new entries)
+- Created dirs: wiki/sources/, wiki/entities/, wiki/concepts/, wiki/questions/, wiki/folds/, wiki/canvases/
 
 ## Active Threads
-- Harness implementation: build phases 0-9 defined, awaiting coding start
+- Harness implementation: build phases 0-9 defined, wiki integration contract ready for coding
+- Next: implement extension hooks in extensions/harness-*.ts with wiki-query pre-action and save post-action

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -17,6 +17,7 @@ This wiki maps the codebase architecture and tracks key software design decision
 | [[schema-orchestration]] | L7 | Archon workflow DAG orchestrates all layers |
 | [[wiki-query-interface]] | L8 | LLM-native search via claude-obsidian skills |
 | [[harness-implementation-plan]] | — | Build phases, token budgets, risk surface |
+| [[harness-wiki-skill-mapping]] | — | Skill-to-layer contract: which wiki skill fires when |
 | [[skills]] | — | Agent capability plugins |
 | [[extensions]] | — | Programmatic hooks |
 | [[bench]] | — | Evaluation tools |
@@ -28,6 +29,7 @@ This wiki maps the codebase architecture and tracks key software design decision
 | [[colocate-wiki]] | Co-locating Wiki with Codebase |
 | [[adr-008]] | Spec-Only Black-Box QA |
 | [[adr-009]] | claude-obsidian Mode B for Persistent Memory |
+| [[adr-010]] | Agentic Harness ↔ Wiki Tight-Coupling Contract |
 
 ## Components
 *(Index of components will go here)*
@@ -36,4 +38,6 @@ This wiki maps the codebase architecture and tracks key software design decision
 *(Index of dependencies will go here)*
 
 ## Flows
-*(Index of flows will go here)*
+| Flow | Summary |
+|------|---------|
+| [[harness-wiki-pipeline]] | Read-first/write-after data flow between harness and wiki |

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -1,4 +1,14 @@
 # Wiki Operations Log
+## [2026-04-28] create | Harness-Wiki Integration Contract (ADR-010 + Skill Mapping + Pipeline)
+- Created: [[adr-010]], [[harness-wiki-skill-mapping]], [[harness-wiki-pipeline]]
+- Updated: [[index]] (added 3 new entries)
+- Created directories: wiki/sources/, wiki/entities/, wiki/concepts/, wiki/questions/, wiki/folds/, wiki/canvases/
+- Key insight: Every harness layer MUST read wiki before acting and write wiki after every state transition. This is enforced at L7 schema orchestration extension hooks. The read-first/write-after contract adds ~3,000-6,000 tokens per subtask but eliminates design drift and wiki staleness entirely.
+- ADR-010 establishes the tight-coupling contract: no layer acts without querying wiki for relevant ADRs, specs, and patterns first; no state transition completes without a wiki write.
+- 11 Obsidian skills are mapped to specific pipeline stages with exact read/write/format responsibilities per layer.
+- 7 staleness elimination rules ensure no page goes stale: status propagation, decision referencing, cross-reference integrity, contradiction resolution, hot cache freshness, lint schedule, index synchronization.
+- Token budget impact: ~20-35% increase overhead, from ~83,500 to ~102,500-117,500 per 5-subtask plan.
+
 
 ## [2026-04-28] ingest | Full GitHub Wiki (re-ingest, previously interrupted)
 - Source: `.raw/ultimate-pi.wiki/` (13 markdown pages from GitHub wiki)

--- a/wiki/modules/harness-wiki-skill-mapping.md
+++ b/wiki/modules/harness-wiki-skill-mapping.md
@@ -1,0 +1,135 @@
+---
+type: module
+title: Harness-Wiki Skill Mapping
+status: active
+created: "2026-04-28"
+updated: "2026-04-28"
+tags: [module, harness, wiki, skills, integration, pipeline]
+sources:
+  - "[[adr-010]]"
+  - "[[adr-009]]"
+  - "[[harness]]"
+related:
+  - "[[harness-wiki-pipeline]]"
+  - "[[wiki-query-interface]]"
+  - "[[persistent-memory]]"
+---
+
+# Harness-Wiki Skill Mapping
+
+Exactly which Obsidian wiki skills are invoked at each pipeline stage. This is the skill→layer contract table referenced by [[adr-010]].
+
+## Skill Inventory
+
+| Skill | Purpose | Trigger Type |
+|-------|---------|-------------|
+| `wiki-query` | Read/search wiki for decisions, specs, patterns | Read (before action) |
+| `wiki-ingest` | Write sources and extracted entities to wiki | Write (after change) |
+| `wiki-lint` | Health check: orphans, dead links, stale claims, frontmatter gaps | Write (periodic) |
+| `wiki-fold` | Rollup log entries into meta-pages | Write (periodic) |
+| `save` | Capture conversation/insight as structured wiki note | Write (after insight) |
+| `obsidian-markdown` | Format wiki pages with correct OFM syntax | Write (all writes) |
+| `obsidian-bases` | Create dynamic database views over wiki pages | Read (dashboards) |
+| `canvas` | Visual map of wiki pages and relationships | Read (exploration) |
+| `autoresearch` | Deep research loop that files findings into wiki | Write (research) |
+| `compress` | Compress wiki pages into caveman format for token savings | Write (periodic) |
+| `defuddle` | Strip clutter from web pages before ingestion | Read (pre-process) |
+
+## Per-Layer Skill Mapping
+
+### L1: Spec Hardening
+
+| Phase | Skill | Action | Detail |
+|-------|-------|--------|--------|
+| **Read** | `wiki-query` | Look up `decisions/` and `modules/spec-hardening` | Find existing hardening rules, ADR constraints, success criteria patterns |
+| **Write** | `save` | File hardened spec as decision page | `decisions/spec-{feature}.md` with frontmatter `type: decision` |
+| **Write** | `wiki-ingest` | Update `modules/spec-hardening.md` status | Add new `> [!success]` or `> [!warning]` callout |
+| **Format** | `obsidian-markdown` | Ensure all spec pages use correct OFM | Wikilinks, callouts, frontmatter |
+
+### L2: Structured Planning
+
+| Phase | Skill | Action | Detail |
+|-------|-------|--------|--------|
+| **Read** | `wiki-query` | Look up `flows/`, `modules/structured-planning` | Prior plans, DAG patterns, proven task decomposition |
+| **Read** | `wiki-query` | Deep search for related ADRs | Cross-reference all decisions that affect the plan |
+| **Write** | `save` | File approved plan as flow page | `flows/plan-{feature}.md` with frontmatter `type: flow`, `plan_status: approved` |
+| **Write** | `wiki-ingest` | Update `modules/structured-planning.md` | Add plan reference, update status |
+| **Format** | `obsidian-markdown` | All plan pages use OFM | Task DAG in code blocks, wikilinks to dependencies |
+
+### L3: Grounding Checkpoints
+
+| Phase | Skill | Action | Detail |
+|-------|-------|--------|--------|
+| **Read** | `wiki-query` | Quick search `hot.md` for current session context | Am I drifting from the approved plan? |
+| **Write** | `wiki-ingest` | Record checkpoint in `log.md` | Append entry with checkpoint type, task_id, pass/fail |
+| **Write** | `save` | If drift detected, file failure pattern | `modules/{feature}.md` with `> [!contradiction]` callout |
+| **Write** | `save` | If checkpoint passed, update hot.md | Refresh recent context with current state |
+
+### L4: Adversarial Verification
+
+| Phase | Skill | Action | Detail |
+|-------|-------|--------|--------|
+| **Read** | `wiki-query` | Look up `decisions/adr-008` and relevant specs | Tests must come from spec ONLY — never from implementation |
+| **Read** | `wiki-query` | Look up `modules/adversarial-verification` | Attack patterns, focus areas, retry limits |
+| **Write** | `save` | File verified success patterns | `modules/{feature}.md` with `status: mature` frontmatter |
+| **Write** | `save` | File failure patterns with critic findings | `modules/{feature}.md` with `> [!contradiction]` callout |
+| **Write** | `wiki-ingest` | Update `modules/adversarial-verification.md` | Add attack results to findings section |
+
+### L5: Automated Observability
+
+| Phase | Skill | Action | Detail |
+|-------|-------|--------|--------|
+| **Read** | `wiki-query` | Look up `modules/automated-observability` | Existing metric definitions, alert conditions |
+| **Write** | `save` | File observability decision | `decisions/observability-{feature}.md` with metric definitions |
+| **Write** | `wiki-ingest` | Update `modules/automated-observability.md` | Add new metrics, update verification table |
+
+### L6: Persistent Memory (Already Wiki-Native)
+
+| Phase | Skill | Action | Detail |
+|-------|-------|--------|--------|
+| **Read** | `wiki-query` | Standard/deep search per depth table | See [[persistent-memory]] three-depth mode |
+| **Write** | `save` | File decisions, patterns, events | Per "Write Patterns by Layer" table in [[persistent-memory]] |
+| **Write** | `wiki-query` | Update `hot.md` | Every session start / shutdown per event hooks |
+| **Write** | `wiki-ingest` | Batch entity/concept extraction | After research or multi-source ingestion |
+| **Periodic** | `wiki-lint` | Health check every 10-15 writes | Per lint schedule in [[wiki-query-interface]] |
+| **Periodic** | `wiki-fold` | Rollup log entries | After 8+ entries per [[adr-010]] contract |
+| **Periodic** | `compress` | Compress high-token pages | When hot.md or frequent pages exceed token budget |
+
+### L7: Schema Orchestration
+
+| Phase | Skill | Action | Detail |
+|-------|-------|--------|--------|
+| **Read** | `wiki-query` | Look up `modules/schema-orchestration` and `flows/` | Pipeline definitions, wave tracking, status |
+| **Write** | `wiki-ingest` | Update orchestration page per wave completion | Status transitions, replan events |
+| **Enforcement** | L7 extension hooks | **Block wiki-skip**: if no wiki-query precedes an action, reject it | This is the enforcement point for [[adr-010]] |
+
+### L8: Wiki Query Interface (Already Wiki-Native)
+
+| Phase | Skill | Action | Detail |
+|-------|-------|--------|--------|
+| **Read** | `wiki-query` | Primary search interface per depth table | See [[wiki-query-interface]] |
+| **Read** | `obsidian-bases` | Dashboard views over wiki pages | Status dashboards, dependency views |
+| **Read** | `canvas` | Visual exploration of page relationships | Architecture maps, dependency graphs |
+| **Write** | `save` | File deep-query results | `questions/research-{topic}.md` |
+
+## Cross-Cutting Skills
+
+These skills operate across layers, not tied to a specific stage:
+
+| Skill | When | Why |
+|-------|------|-----|
+| `autoresearch` | Before L1-L2 for unknown domains | Fills gaps in wiki before spec hardening begins |
+| `defuddle` | Before `wiki-ingest` for web sources | Strips clutter, saves 40-60% tokens on ingestion |
+| `compress` | When any wiki page exceeds token budget | Keeps L6 reads efficient |
+| `wiki-fold` | After 8+ entries in `log.md` | Prevents log bloat, creates fold summaries |
+| `canvas` | On-demand for visual architecture | Architecture diagrams, dependency maps |
+
+## Enforcement Points
+
+The harness enforces the read-first/write-after contract at two chokepoints:
+
+1. **L7 Schema Orchestration**: Before dispatching any layer, the orchestrator checks that `wiki-query` has been called for the relevant pages. If not, it inserts a read step.
+2. **Extension hooks**: Every `extensions/harness-*.ts` file must call the appropriate wiki skill before/after its layer logic. The hook pattern is:
+   - `pre_action`: Call `wiki-query` for relevant docs
+   - `post_action`: Call `save` or `wiki-ingest` to persist outcomes
+   - `periodic`: Call `wiki-lint` every 10-15 writes

--- a/wiki/modules/harness.md
+++ b/wiki/modules/harness.md
@@ -8,6 +8,8 @@ tags: [module, harness, planning, architecture]
 sources:
   - "[[harness-implementation-plan]]"
 related:
+  - "[[harness-wiki-skill-mapping]]"
+  - "[[harness-wiki-pipeline]]"
   - "[[spec-hardening]]"
   - "[[structured-planning]]"
   - "[[grounding-checkpoints]]"
@@ -38,6 +40,7 @@ An 8-layer mandatory pipeline — every task flows through all layers. No layer 
 ## Key Design Decisions
 - **[[adr-008|Black-box QA]]**: Tests from spec only, never from implementation
 - **[[adr-009|claude-obsidian Mode B]]**: Replaces Vectra + embeddings with LLM-native search
+- **[[adr-010|Wiki Tight-Coupling]]**: Every layer reads wiki first, writes wiki after every state transition
 - **No skip rule**: Verification is mandatory. Agent confidence is not evidence.
 
 ## Build Sequence

--- a/wiki/modules/persistent-memory.md
+++ b/wiki/modules/persistent-memory.md
@@ -9,6 +9,8 @@ layer: "6"
 sources:
   - "[[harness-implementation-plan]]"
 related:
+  - "[[harness-wiki-pipeline]]"
+  - "[[harness-wiki-skill-mapping]]"
   - "[[agentic-harness]]"
   - "[[wiki-query-interface]]"
   - "[[schema-orchestration]]"


### PR DESCRIPTION
- Add ADR-010: read-first write-after contract for every harness layer
- Add harness-wiki-skill-mapping module: 11 Obsidian skills mapped to pipeline stages
- Add harness-wiki-pipeline flow: exact data flow, write-after events, staleness rules
- Update harness.md and persistent-memory.md with cross-links
- Update index.md, log.md, hot.md with new entries
- Create missing wiki directories (sources, entities, concepts, questions, folds, canvases)