### PR TITLE
chore(harness): ignore skills-lock.json from linting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ pnpm-debug.log*
 
 # Raw source files (immutable, not committed)
 .raw/
+
+# Skill lock file (auto-generated, skip lint)
+skills-lock.json


### PR DESCRIPTION
- Add skills-lock.json to .gitignore so biome skips it via useIgnoreFile
- Remove ineffective experimentalScannerIgnores from biome.json