### PR TITLE
fix(wiki): lint autofix — frontmatter gaps, dead links, stub pages

### DIFF
--- a/vault/wiki/_templates/decision.md
+++ b/vault/wiki/_templates/decision.md
@@ -9,6 +9,8 @@ context: ""
 tags: [decision]
 created: ""
 updated: ""
+created: 2026-04-30
+updated: 2026-04-30
 ---
 # {{title}}
 

--- a/vault/wiki/_templates/flow.md
+++ b/vault/wiki/_templates/flow.md
@@ -4,6 +4,8 @@ status: active
 tags: [flow]
 created: ""
 updated: ""
+created: 2026-04-30
+updated: 2026-04-30
 ---
 # {{title}}
 

--- a/vault/wiki/_templates/module.md
+++ b/vault/wiki/_templates/module.md
@@ -12,5 +12,7 @@ used_by: []
 tags: [module]
 created: ""
 updated: ""
+created: 2026-04-30
+updated: 2026-04-30
 ---
 # {{title}}

--- a/vault/wiki/concepts/agent-codebase-interface.md
+++ b/vault/wiki/concepts/agent-codebase-interface.md
@@ -9,7 +9,7 @@ tags:
   - interface-design
 related:
   - "[[swe-agent-aci]]"
-  - "[[agent-first-exploration]]"
+  - "[[research-agent-first-codebase-exploration]]"
 status: developing
 ---
 

--- a/vault/wiki/concepts/agent-search-enforcement.md
+++ b/vault/wiki/concepts/agent-search-enforcement.md
@@ -13,6 +13,7 @@ related:
   - "[[mcp-tool-routing]]"
   - "[[agentic-harness-context-enforcement]]"
   - "[[Research: semantic code search tools]]"
+title: "agent search enforcement"
 ---
 
 # agent search enforcement

--- a/vault/wiki/concepts/agentic-harness.md
+++ b/vault/wiki/concepts/agentic-harness.md
@@ -1,0 +1,34 @@
+---
+type: concept
+title: "Agentic Harness"
+created: 2026-04-30
+updated: 2026-04-30
+status: seed
+tags: [#concept, #harness]
+related:
+  - "[[harness]]"
+  - "[[harness-implementation-plan]]"
+  - "[[harness-wiki-skill-mapping]]"
+---
+
+# Agentic Harness
+
+> [!stub] This is a stub page. See [[harness]] for the full module documentation.
+
+The agentic harness is the central execution pipeline in the ultimate-pi architecture. It enforces an 8-layer mandatory workflow where every task must flow through all layers without skipping.
+
+## What it does
+
+- Enforces structured execution (no ad-hoc coding)
+- Runs adversarial verification (critic agents attack, not review)
+- Maintains persistent memory via the wiki vault
+- Orchestrates multi-step plans with grounding checkpoints
+
+## Key pages
+
+- [[harness]] — full module documentation
+- [[harness-implementation-plan]] — build phases and token budgets
+- [[harness-wiki-pipeline]] — data flow between harness and wiki
+- [[adr-008]] — Spec-Only Black-Box QA decision
+- [[adr-009]] — Mode B persistent memory decision
+- [[adr-010]] — Harness-wiki tight-coupling contract

--- a/vault/wiki/concepts/ast-compression.md
+++ b/vault/wiki/concepts/ast-compression.md
@@ -1,0 +1,19 @@
+---
+type: concept
+title: "ast-compression"
+created: 2026-04-30
+updated: 2026-04-30
+status: seed
+tags: [#concept, #lean-ctx, #context-optimization]
+related:
+  - "[[lean-ctx]]"
+  - "[[ast-truncation]]"
+---
+
+# AST Compression
+
+> [!stub] See also: [[ast-truncation]] for the harness-specific implementation.
+
+lean-ctx's approach to code compression: use tree-sitter to parse code in 18 languages, extract only signatures, types, and logic bodies, and strip comments, whitespace, and non-essential syntax. Achieves 60-95% token reduction on source files.
+
+Differs from [[ast-truncation]] (which stubs function bodies) in that AST compression preserves logic but strips non-semantic elements, while AST truncation removes function bodies entirely for high-level structural views.

--- a/vault/wiki/concepts/context-continuity.md
+++ b/vault/wiki/concepts/context-continuity.md
@@ -1,0 +1,22 @@
+---
+type: concept
+title: "context-continuity"
+created: 2026-04-30
+updated: 2026-04-30
+status: seed
+tags: [#concept, #context-optimization, #session-management]
+related:
+  - "[[context-mode]]"
+  - "[[lean-ctx]]"
+---
+
+# Context Continuity
+
+> [!stub] This is a stub page.
+
+The ability for AI coding agents to preserve session state across context compaction events. Both context-mode and lean-ctx implement this, but differently:
+
+- **context-mode**: Captures 26 event types to SessionDB for cross-compaction continuity
+- **lean-ctx**: Uses CCP (Cross-session Continuity Protocol) with scratchpad messaging for multi-agent session sharing
+
+Without context continuity, each context window compaction resets the agent's working memory, losing accumulated understanding of the codebase.

--- a/vault/wiki/concepts/context-mode.md
+++ b/vault/wiki/concepts/context-mode.md
@@ -1,0 +1,38 @@
+---
+type: concept
+title: "context-mode"
+created: 2026-04-30
+updated: 2026-04-30
+status: seed
+tags: [#concept, #tool, #context-optimization]
+sources:
+  - "[[context-mode-website]]"
+related:
+  - "[[Research: context-mode vs lean-ctx]]"
+  - "[[think-in-code]]"
+  - "[[agentic-harness-context-enforcement]]"
+---
+
+# context-mode
+
+> [!stub] This is a stub page. See [[context-mode-website]] for source documentation.
+
+context-mode is an MCP-based context optimization tool by B. Mert Köseoğlu (11K+ GitHub stars). It intercepts tool output and sandboxes it into SQLite FTS5 with BM25 ranking, preventing raw tool output from entering the agent's context window.
+
+## Architecture
+
+Uses **intercept-and-sandbox**: raw tool output never enters context. Instead, output is indexed into FTS5 and the agent queries on demand. This achieves up to 99.5% token reduction.
+
+## Key features
+
+- FTS5 sandbox with BM25 ranking
+- "Think in Code" paradigm enforcement
+- 26-event session continuity
+- ELv2 license, TypeScript/Node.js
+
+## Key pages
+
+- [[context-mode-website]] — source documentation
+- [[Research: context-mode vs lean-ctx]] — comparison with lean-ctx
+- [[think-in-code]] — the "Think in Code" paradigm
+- [[fts5-sandbox]] — architecture detail

--- a/vault/wiki/concepts/fts5-sandbox.md
+++ b/vault/wiki/concepts/fts5-sandbox.md
@@ -1,0 +1,19 @@
+---
+type: concept
+title: "fts5-sandbox"
+created: 2026-04-30
+updated: 2026-04-30
+status: seed
+tags: [#concept, #context-mode, #architecture]
+related:
+  - "[[context-mode]]"
+  - "[[Research: context-mode vs lean-ctx]]"
+---
+
+# FTS5 Sandbox
+
+> [!stub] This is a stub page. See [[context-mode]] for full documentation.
+
+context-mode's core architecture: intercept agent tool calls, run them in a sandboxed subprocess, index the output into SQLite FTS5 with BM25 ranking, and let the agent search the indexed output on demand. Raw tool output never enters the agent's context window — the agent queries the sandbox instead.
+
+Achieves up to 99.5% token reduction on large tool outputs (e.g., 56.2KB Playwright output → 299B).

--- a/vault/wiki/concepts/hybrid-code-search.md
+++ b/vault/wiki/concepts/hybrid-code-search.md
@@ -12,6 +12,7 @@ related:
   - "[[ck-tool]]"
   - "[[agent-search-enforcement]]"
   - "[[Research: semantic code search tools]]"
+title: "hybrid code search"
 ---
 
 # hybrid code search

--- a/vault/wiki/concepts/mcp-tool-routing.md
+++ b/vault/wiki/concepts/mcp-tool-routing.md
@@ -12,6 +12,7 @@ related:
   - "[[agent-search-enforcement]]"
   - "[[ck-tool]]"
   - "[[Research: semantic code search tools]]"
+title: "MCP tool routing"
 ---
 
 # MCP tool routing

--- a/vault/wiki/concepts/shell-pattern-compression.md
+++ b/vault/wiki/concepts/shell-pattern-compression.md
@@ -1,0 +1,24 @@
+---
+type: concept
+title: "shell-pattern-compression"
+created: 2026-04-30
+updated: 2026-04-30
+status: seed
+tags: [#concept, #lean-ctx, #context-optimization]
+related:
+  - "[[lean-ctx]]"
+  - "[[Research: context-mode vs lean-ctx]]"
+---
+
+# shell-pattern-compression
+
+> [!stub] This is a stub page. See [[lean-ctx]] and [[leanctx-website]] for details.
+
+A lean-ctx feature that recognizes 90+ command patterns (git, npm, cargo, docker, kubectl, etc.) and intelligently compresses their output. Instead of passing raw terminal output to the LLM, lean-ctx strips irrelevant lines, summarizes, and formats output for maximum information density per token.
+
+Part of lean-ctx's broader context compression strategy alongside AST-based code compression.
+
+## Key pages
+
+- [[lean-ctx]] — Context Runtime for AI Agents
+- [[leanctx-website]] — source documentation

--- a/vault/wiki/concepts/verification-drift-detection.md
+++ b/vault/wiki/concepts/verification-drift-detection.md
@@ -1,0 +1,19 @@
+---
+type: concept
+title: "verification-drift-detection"
+created: 2026-04-30
+updated: 2026-04-30
+status: seed
+tags: [#concept, #harness, #testing]
+related:
+  - "[[execution-feedback-loop]]"
+  - "[[grounding-checkpoints]]"
+---
+
+# Verification Drift Detection
+
+> [!stub] See [[grounding-checkpoints]] for the harness implementation.
+
+Detects when an agent's implementation drifts away from the spec or when verification results become stale. Part of the execution feedback loop: after each change, verify that the output still matches expected behavior. Drift detection triggers re-grounding — forcing the agent to re-read the spec before continuing.
+
+In the ultimate-pi harness, this is implemented by Layer 3 ([[grounding-checkpoints]]), which enforces smallest-verifiable-change + drift detection on every checkpoint.

--- a/vault/wiki/decisions/2026-04-30-pi-lean-ctx-native.md
+++ b/vault/wiki/decisions/2026-04-30-pi-lean-ctx-native.md
@@ -12,6 +12,8 @@ related:
   - "[[lean-ctx]]"
   - "[[leanctx-website]]"
   - "[[Research: context-mode vs lean-ctx]]"
+updated: 2026-04-30
+title: "ADR: Adopt pi-lean-ctx Native Package, Drop Custom Extension"
 ---
 
 # ADR: Adopt pi-lean-ctx Native Package, Drop Custom Extension

--- a/vault/wiki/decisions/adr-008.md
+++ b/vault/wiki/decisions/adr-008.md
@@ -10,6 +10,8 @@ sources:
 related:
   - "[[adversarial-verification]]"
   - "[[agentic-harness]]"
+created: 2026-04-30
+updated: 2026-04-30
 ---
 
 # ADR-008: Spec-Only Black-Box QA

--- a/vault/wiki/decisions/adr-009.md
+++ b/vault/wiki/decisions/adr-009.md
@@ -11,6 +11,8 @@ related:
   - "[[persistent-memory]]"
   - "[[wiki-query-interface]]"
   - "[[agentic-harness]]"
+created: 2026-04-30
+updated: 2026-04-30
 ---
 
 # ADR-009: claude-obsidian Mode B for Persistent Memory

--- a/vault/wiki/decisions/colocate-wiki.md
+++ b/vault/wiki/decisions/colocate-wiki.md
@@ -9,6 +9,7 @@ context: "Should the architecture wiki be co-located in the same repository as t
 tags: [decision, architecture, documentation]
 created: "2026-04-28"
 updated: "2026-04-28"
+title: "Co-locating Wiki with Codebase"
 ---
 # Co-locating Wiki with Codebase
 

--- a/vault/wiki/entities/autodev-codebase.md
+++ b/vault/wiki/entities/autodev-codebase.md
@@ -1,0 +1,18 @@
+---
+type: entity
+title: "autodev-codebase"
+created: 2026-04-30
+updated: 2026-04-30
+status: seed
+tags: [#entity, #tool, #code-search]
+related:
+  - "[[Research: semantic code search tools]]"
+---
+
+# autodev-codebase
+
+> [!stub] Minimal entity stub.
+
+TypeScript MCP server (116 ⭐) with call graphs + Ollama embeddings for code search. Combines structural analysis (call graphs) with semantic search (embeddings).
+
+Mentioned in [[Research: semantic code search tools]] as an alternative to [[ck-tool]].

--- a/vault/wiki/entities/ck-tool.md
+++ b/vault/wiki/entities/ck-tool.md
@@ -15,6 +15,7 @@ related:
   - "[[hybrid-code-search]]"
   - "[[agent-search-enforcement]]"
   - "[[Research: semantic code search tools]]"
+title: "ck (seek)"
 ---
 
 # ck (seek)

--- a/vault/wiki/entities/codesearch.md
+++ b/vault/wiki/entities/codesearch.md
@@ -1,0 +1,18 @@
+---
+type: entity
+title: "codesearch"
+created: 2026-04-30
+updated: 2026-04-30
+status: seed
+tags: [#entity, #tool, #code-search]
+related:
+  - "[[Research: semantic code search tools]]"
+---
+
+# codesearch
+
+> [!stub] Minimal entity stub.
+
+Rust MCP server (16 ⭐) designed for Claude Code / OpenCode integration. Provides semantic code search as an MCP tool. Younger and less mature than [[ck-tool]] or [[vgrep-tool]].
+
+Mentioned in [[Research: semantic code search tools]] as a secondary alternative.

--- a/vault/wiki/entities/lean-ctx.md
+++ b/vault/wiki/entities/lean-ctx.md
@@ -1,0 +1,32 @@
+---
+type: entity
+title: "lean-ctx"
+created: 2026-04-30
+updated: 2026-04-30
+status: seed
+tags: [#entity, #tool]
+sources: 
+  - "[[leanctx-website]]"
+related:
+  - "[[Research: context-mode vs lean-ctx]]"
+---
+
+# lean-ctx
+
+> [!stub] This is a stub page. See [[leanctx-website]] for the source documentation.
+
+lean-ctx (pi-lean-ctx) is the Context Runtime for AI Agents — a tool that compresses LLM context by up to 99% through structured file reading, tree-sitter AST parsing, and advanced shell output compression.
+
+## What it provides
+
+- 46+ MCP tools for agent context management
+- 10 reading modes (signatures, maps, full reads)
+- 90+ shell patterns for command output compression
+- Tree-sitter AST for 18 languages
+- Native Pi package integration
+
+## Key pages
+
+- [[leanctx-website]] — source: leanctx.com
+- [[Research: context-mode vs lean-ctx]] — comparison with context-mode
+- [[2026-04-30-pi-lean-ctx-native]] — ADR: adopting pi-lean-ctx native package

--- a/vault/wiki/entities/ops-codegraph-tool.md
+++ b/vault/wiki/entities/ops-codegraph-tool.md
@@ -1,0 +1,18 @@
+---
+type: entity
+title: "ops-codegraph-tool"
+created: 2026-04-30
+updated: 2026-04-30
+status: seed
+tags: [#entity, #tool, #code-search]
+related:
+  - "[[Research: semantic code search tools]]"
+---
+
+# ops-codegraph-tool
+
+> [!stub] Minimal entity stub.
+
+Python dependency graph engine + semantic search + boundary enforcement (41 ⭐). Combines code dependency analysis with semantic search capabilities.
+
+Mentioned in [[Research: semantic code search tools]] as a secondary alternative to [[ck-tool]].

--- a/vault/wiki/entities/vgrep-tool.md
+++ b/vault/wiki/entities/vgrep-tool.md
@@ -14,6 +14,7 @@ related:
   - "[[vgrep-semantic-search]]"
   - "[[ck-tool]]"
   - "[[Research: semantic code search tools]]"
+title: "vgrep"
 ---
 
 # vgrep

--- a/vault/wiki/hot.md
+++ b/vault/wiki/hot.md
@@ -2,6 +2,8 @@
 type: meta
 title: "Hot Cache"
 updated: 2026-04-30T10:00:00
+created: 2026-04-30
+tags: []
 ---
 
 # Recent Context

--- a/vault/wiki/log.md
+++ b/vault/wiki/log.md
@@ -24,7 +24,7 @@
 - Rounds: 1 (direct source analysis — both service homepages, READMEs, APIs, output formats)
 - Sources found: 2
 - Pages created: [[gitingest]], [[gitreverse]], [[codebase-to-context-ingestion]], [[research-gitingest-gitreverse-integration]]
-- Synthesis: [[Research: GitIngest and GitReverse Integration]]
+- Synthesis: [[research-gitingest-gitreverse-integration]]
 - Key finding: Gitingest (codebase → structured text) is a strong fit for the harness. It fills a gap — the harness has no bulk codebase ingestion mechanism, only file-by-file lean-ctx reading. GitReverse (repo → synthetic LLM prompt) is not useful — it generates prompts FROM repos, but the harness receives prompts. Recommendation: integrate Gitingest via a `/gitingest` skill (renamed from `/ingest` to avoid clash with wiki-ingest). Skip GitReverse.
 
 ## [2026-04-30] autoresearch | WOZCODE Token-Reduction Architecture
@@ -32,14 +32,14 @@
 - Sources found: 1
 - Pages created: [[research-wozcode-token-reduction]], [[wozcode]], [[ast-truncation]], [[fuzzy-edit-matching]], [[inline-post-edit-validation]], [[model-routing-agents]]
 - Pages updated: [[harness-implementation-plan]] (added Phases 10-13 with WOZCODE-inspired enhancements), [[index]], [[hot]]
-- Synthesis: [[Research: WOZCODE Token-Reduction Architecture]]
+- Synthesis: [[research-wozcode-token-reduction]]
 - Key finding: WOZCODE achieves 25-55% token reduction via three compounding levers — smarter search (AST truncation), batched fuzzy edits (near-miss tolerance), and quality loop (inline post-edit validation). These map to 4 new harness phases (10-13) requiring 5 fundamental agent architecture changes: model router layer, inline validation pipeline, AST-aware tool primitives, non-exact tool matching, and tool result intermediation.
 
 ## [2026-04-30] autoresearch | Agent-First Codebase Exploration Strategies
 - Rounds: 2 (broad search + gap fill → direct synthesis)
 - Sources found: 5
 - Pages created: [[research-agent-first-codebase-exploration]], [[oss-guide-codebase-exploration]], [[aider-repomap-tree-sitter]], [[swe-agent-aci]], [[swe-bench]], [[openhands-platform]], [[agent-codebase-interface]], [[progressive-disclosure-agents]], [[repo-map-ranking]], [[execution-feedback-loop]]
-- Synthesis: [[Research: Agent-First Codebase Exploration Strategies]]
+- Synthesis: [[research-agent-first-codebase-exploration]]
 - Key finding: Humans and agents need fundamentally different codebase interfaces. Humans learn by using projects; agents learn by mapping them. Every human-centric OSS technique maps to an agent-native equivalent via Agent-Codebase Interface (ACI) design, with agents excelling at symbol ingestion and cross-reference tracking while struggling with context window limits and lack of visual pattern recognition.
 
 ## [2026-04-28] create | Harness-Wiki Integration Contract (ADR-010 + Skill Mapping + Pipeline)

--- a/vault/wiki/meta/dashboard.md
+++ b/vault/wiki/meta/dashboard.md
@@ -1,0 +1,28 @@
+---
+type: meta
+title: "Dashboard"
+updated: 2026-04-30
+created: 2026-04-30
+tags: []
+---
+# Wiki Dashboard
+
+## Recent Activity
+```dataview
+TABLE type, status, updated FROM "wiki" SORT updated DESC LIMIT 15
+```
+
+## Seed Pages (Need Development)
+```dataview
+LIST FROM "wiki" WHERE status = "seed" SORT updated ASC
+```
+
+## Entities Missing Sources
+```dataview
+LIST FROM "wiki/entities" WHERE !sources OR length(sources) = 0
+```
+
+## Open Questions
+```dataview
+LIST FROM "wiki/questions" WHERE answer_quality = "draft" SORT created DESC
+```

--- a/vault/wiki/meta/lint-report-2026-04-30.md
+++ b/vault/wiki/meta/lint-report-2026-04-30.md
@@ -1,0 +1,96 @@
+---
+type: meta
+title: "Lint Report 2026-04-30"
+created: 2026-04-30
+updated: 2026-04-30
+tags: [meta, lint]
+status: complete
+---
+
+# Lint Report: 2026-04-30
+
+## Summary
+- Pages scanned: 72 (excluding meta)
+- Issues found: 71
+- Auto-fixed: 68
+- Needs review: 3 (all expected/acceptable)
+
+---
+
+## Auto-Fixed (68 issues resolved)
+
+### Frontmatter gaps (48 → 0)
+All pages now have: `type`, `title`, `created`, `updated`, `status`, `tags`.
+- 13 source pages: added missing fields
+- 22 concept/entity/question/module pages: added missing fields
+- 3 template pages: added `created`, `updated`
+- `overview`: added complete frontmatter
+
+### Dead links resolved (11)
+- `[[agent-first-exploration]]` → `[[research-agent-first-codebase-exploration]]`
+- `[[Progressive Disclosure for Agents]]` → `[[progressive-disclosure-agents]]`
+- `[[Adversarial Verification]]` → `[[adversarial-verification]]`
+- `[[automated-observability\]]` → `[[automated-observability]]` (typo + escaped pipe)
+- `[[lean-ctx]]` — stub created, index entry now resolves
+- `[[agentic-harness]]` — stub created
+- 3 log.md entries updated to correct filenames
+- `[[ast-compression]]`, `[[context-mode]]`, `[[shell-pattern-compression]]`, `[[fts5-sandbox]]`, `[[context-continuity]]`, `[[verification-drift-detection]]`, `[[codesearch]]`, `[[autodev-codebase]]`, `[[ops-codegraph-tool]]` — stubs created
+
+### Stub pages created (11)
+- `concepts/agentic-harness.md`
+- `concepts/context-mode.md`
+- `concepts/ast-compression.md`
+- `concepts/shell-pattern-compression.md`
+- `concepts/fts5-sandbox.md`
+- `concepts/context-continuity.md`
+- `concepts/verification-drift-detection.md`
+- `entities/lean-ctx.md`
+- `entities/codesearch.md`
+- `entities/autodev-codebase.md`
+- `entities/ops-codegraph-tool.md`
+
+### Style fix (1)
+- `sources/gitreverse.md`: "kind of" → declarative
+
+---
+
+## Remaining (3 — all expected)
+
+| Issue | Page | Status |
+|-------|------|--------|
+| `[[ "$*" =~ [[:space:]] ]]` | `concepts/agent-search-enforcement.md` | **False positive** — bash code block, not a wikilink |
+| `[[new-adr]]` | `flows/harness-wiki-pipeline.md` | **Template placeholder** — pipeline doc example, intentional |
+| `[[old-adr]]` | `flows/harness-wiki-pipeline.md` | **Template placeholder** — pipeline doc example, intentional |
+
+---
+
+## Orphan Pages (all expected)
+
+- `_templates/decision`, `_templates/flow`, `_templates/module` — templates
+- `overview.md` — seed entry point
+- `meta/lint-report-2026-04-30.md`, `meta/dashboard.md` — meta artifacts
+
+---
+
+## Cross-Reference Gaps (informational)
+
+Entities mentioned without wikilinks in some pages (harness, index, skills, extensions). Not auto-fixed — add wikilinks during next content pass.
+
+---
+
+## Artifacts Created
+
+- `vault/wiki/meta/lint-report-2026-04-30.md` — this report
+- `vault/wiki/meta/dashboard.md` — Dataview dashboard
+- `vault/wiki/meta/overview.canvas` — visual domain map
+- 11 stub pages (see above)
+
+---
+
+## Address Validation
+
+Skipped. DragonScale not configured.
+
+## Semantic Tiling
+
+Skipped. Ollama/tiling script not available.

--- a/vault/wiki/meta/overview.canvas
+++ b/vault/wiki/meta/overview.canvas
@@ -1,0 +1,43 @@
+{
+  "nodes": [
+    {"id": "1", "type": "file", "file": "wiki/overview.md", "x": 0, "y": 0, "width": 300, "height": 140, "color": "1"},
+    {"id": "2", "type": "file", "file": "wiki/index.md", "x": 400, "y": 0, "width": 300, "height": 140, "color": "1"},
+    {"id": "3", "type": "file", "file": "wiki/concepts/agent-codebase-interface.md", "x": -400, "y": 200, "width": 280, "height": 120, "color": "2"},
+    {"id": "4", "type": "file", "file": "wiki/concepts/progressive-disclosure-agents.md", "x": -400, "y": 370, "width": 280, "height": 120, "color": "2"},
+    {"id": "5", "type": "file", "file": "wiki/concepts/repo-map-ranking.md", "x": -400, "y": 540, "width": 280, "height": 120, "color": "2"},
+    {"id": "6", "type": "file", "file": "wiki/concepts/codebase-to-context-ingestion.md", "x": 0, "y": 200, "width": 280, "height": 120, "color": "2"},
+    {"id": "7", "type": "file", "file": "wiki/concepts/think-in-code.md", "x": 0, "y": 370, "width": 280, "height": 120, "color": "2"},
+    {"id": "8", "type": "file", "file": "wiki/concepts/hybrid-code-search.md", "x": 0, "y": 540, "width": 280, "height": 120, "color": "2"},
+    {"id": "9", "type": "file", "file": "wiki/concepts/agent-search-enforcement.md", "x": 400, "y": 200, "width": 280, "height": 120, "color": "2"},
+    {"id": "10", "type": "file", "file": "wiki/concepts/model-routing-agents.md", "x": 400, "y": 370, "width": 280, "height": 120, "color": "2"},
+    {"id": "11", "type": "file", "file": "wiki/modules/harness.md", "x": 800, "y": 0, "width": 280, "height": 120, "color": "5"},
+    {"id": "12", "type": "file", "file": "wiki/modules/spec-hardening.md", "x": 800, "y": 170, "width": 280, "height": 120, "color": "5"},
+    {"id": "13", "type": "file", "file": "wiki/modules/structured-planning.md", "x": 800, "y": 340, "width": 280, "height": 120, "color": "5"},
+    {"id": "14", "type": "file", "file": "wiki/modules/grounding-checkpoints.md", "x": 800, "y": 510, "width": 280, "height": 120, "color": "5"},
+    {"id": "15", "type": "file", "file": "wiki/concepts/execution-feedback-loop.md", "x": 400, "y": 540, "width": 280, "height": 120, "color": "2"},
+    {"id": "16", "type": "file", "file": "wiki/decisions/adr-008.md", "x": -400, "y": 710, "width": 280, "height": 120, "color": "4"},
+    {"id": "17", "type": "file", "file": "wiki/decisions/adr-009.md", "x": 0, "y": 710, "width": 280, "height": 120, "color": "4"},
+    {"id": "18", "type": "file", "file": "wiki/decisions/adr-010.md", "x": 400, "y": 710, "width": 280, "height": 120, "color": "4"},
+    {"id": "19", "type": "file", "file": "wiki/decisions/2026-04-30-pi-lean-ctx-native.md", "x": 800, "y": 680, "width": 280, "height": 120, "color": "4"},
+    {"id": "20", "type": "file", "file": "wiki/questions/Research: semantic code search tools.md", "x": -800, "y": 200, "width": 280, "height": 120, "color": "6"},
+    {"id": "21", "type": "file", "file": "wiki/questions/Research: context-mode vs lean-ctx.md", "x": -800, "y": 370, "width": 280, "height": 120, "color": "6"},
+    {"id": "22", "type": "file", "file": "wiki/questions/research-wozcode-token-reduction.md", "x": -800, "y": 540, "width": 280, "height": 120, "color": "6"}
+  ],
+  "edges": [
+    {"id": "e1", "fromNode": "1", "toNode": "2", "fromSide": "right", "toSide": "left"},
+    {"id": "e2", "fromNode": "2", "toNode": "11", "fromSide": "right", "toSide": "left"},
+    {"id": "e3", "fromNode": "3", "toNode": "4"},
+    {"id": "e4", "fromNode": "4", "toNode": "5"},
+    {"id": "e5", "fromNode": "6", "toNode": "7"},
+    {"id": "e6", "fromNode": "7", "toNode": "8"},
+    {"id": "e7", "fromNode": "9", "toNode": "10"},
+    {"id": "e8", "fromNode": "10", "toNode": "15"},
+    {"id": "e9", "fromNode": "11", "toNode": "12"},
+    {"id": "e10", "fromNode": "12", "toNode": "13"},
+    {"id": "e11", "fromNode": "13", "toNode": "14"},
+    {"id": "e12", "fromNode": "16", "toNode": "17"},
+    {"id": "e13", "fromNode": "17", "toNode": "18"},
+    {"id": "e14", "fromNode": "20", "toNode": "21"},
+    {"id": "e15", "fromNode": "21", "toNode": "22"}
+  ]
+}

--- a/vault/wiki/modules/adversarial-verification.md
+++ b/vault/wiki/modules/adversarial-verification.md
@@ -31,7 +31,7 @@ Layer 4 of the [[agentic-harness]]. Critic agents **attack**, not review. No cod
 
 | Verdict | Action |
 |---------|--------|
-| `pass` | Proceed to [[automated-observability\|Layer 5]] |
+| `pass` | Proceed to [[automated-observability|Layer 5]] |
 | `fail` | Rework subtask |
 | `conditional_pass` | Proceed with logged caveats |
 

--- a/vault/wiki/modules/bench.md
+++ b/vault/wiki/modules/bench.md
@@ -12,6 +12,7 @@ used_by: []
 tags: [module, bench]
 created: "2026-04-28"
 updated: "2026-04-28"
+title: "Benchmarks"
 ---
 # Benchmarks
 

--- a/vault/wiki/modules/extensions.md
+++ b/vault/wiki/modules/extensions.md
@@ -12,6 +12,7 @@ used_by: ["pi"]
 tags: [module, extensions]
 created: "2026-04-28"
 updated: "2026-04-28"
+title: "Extensions"
 ---
 # Extensions
 

--- a/vault/wiki/modules/skills.md
+++ b/vault/wiki/modules/skills.md
@@ -12,6 +12,7 @@ used_by: ["pi"]
 tags: [module, skills]
 created: "2026-04-28"
 updated: "2026-04-28"
+title: "Agent Skills"
 ---
 # Agent Skills
 

--- a/vault/wiki/overview.md
+++ b/vault/wiki/overview.md
@@ -1,3 +1,11 @@
+---
+type: overview
+title: "Codebase Architecture Overview"
+created: 2026-04-30
+updated: 2026-04-30
+status: seed
+tags: [meta, overview]
+---
 # Codebase Architecture Overview
 
 Provides a high-level overview of the repository's architecture, key modules, and the main interaction flows.

--- a/vault/wiki/questions/research-agent-first-codebase-exploration.md
+++ b/vault/wiki/questions/research-agent-first-codebase-exploration.md
@@ -82,7 +82,7 @@ The core finding: humans and agents need fundamentally different interfaces to t
 
 **Human strategy**: Narrow scope to the relevant subsystem; treat everything else as a black box.
 
-**Agent equivalent**: Identical principle, but implemented through [[Progressive Disclosure for Agents]] — a layered information architecture (L0: project map, L1: symbol map, L2: file context, L3: deep context). Agent starts with L0 always available, queries deeper layers on demand.
+**Agent equivalent**: Identical principle, but implemented through [[progressive-disclosure-agents]] — a layered information architecture (L0: project map, L1: symbol map, L2: file context, L3: deep context). Agent starts with L0 always available, queries deeper layers on demand.
 
 **Key difference**: Humans scope down through intuition. Agents scope down through structured queries — "show me all callers of function X" or "show me all implementations of interface Y." The tooling must support these queries efficiently.
 
@@ -110,7 +110,7 @@ The core finding: humans and agents need fundamentally different interfaces to t
 
 **Human strategy**: Rubber duck debugging, mentor review, explain to someone else.
 
-**Agent equivalent**: [[Adversarial Verification]] — a separate critic agent reviews the proposed change, checks for edge cases, verifies against specifications, and either approves or sends back with specific failure reasons. This replaces the human mentor role.
+**Agent equivalent**: [[adversarial-verification]] — a separate critic agent reviews the proposed change, checks for edge cases, verifies against specifications, and either approves or sends back with specific failure reasons. This replaces the human mentor role.
 
 ### 10. "Hack it, then get it right" → "Iterative refinement with verification gates" (Source: [[oss-guide-codebase-exploration]])
 

--- a/vault/wiki/sources/aider-repomap-tree-sitter.md
+++ b/vault/wiki/sources/aider-repomap-tree-sitter.md
@@ -19,6 +19,8 @@ tags:
   - tree-sitter
   - repo-map
   - context-window
+created: 2023-10-22
+updated: 2026-04-30
 ---
 
 # Building a better repository map with tree-sitter

--- a/vault/wiki/sources/ck-semantic-search.md
+++ b/vault/wiki/sources/ck-semantic-search.md
@@ -23,6 +23,9 @@ related:
   - "[[ck-tool]]"
   - "[[hybrid-code-search]]"
   - "[[Research: semantic code search tools]]"
+created: 2025-08-30
+updated: 2026-04-30
+status: ingested
 ---
 
 # ck (seek): Hybrid Code Search

--- a/vault/wiki/sources/context-mode-website.md
+++ b/vault/wiki/sources/context-mode-website.md
@@ -13,6 +13,10 @@ key_claims:
   - "30× fewer tokens across full sessions"
   - "Used at Microsoft, Google, Meta, ByteDance, Red Hat, GitHub"
   - "HN #1 with 570+ points"
+created: 2026-04-30
+updated: 2026-04-30
+status: ingested
+tags: [#source/website]
 ---
 
 # context-mode.com

--- a/vault/wiki/sources/gitingest.md
+++ b/vault/wiki/sources/gitingest.md
@@ -18,6 +18,10 @@ tags:
   - codebase-ingestion
   - llm-context
   - tool
+created: 2026-04-30
+updated: 2026-04-30
+status: ingested
+title: "Gitingest"
 ---
 
 # Gitingest

--- a/vault/wiki/sources/gitreverse.md
+++ b/vault/wiki/sources/gitreverse.md
@@ -18,13 +18,17 @@ tags:
   - prompt-generation
   - repo-analysis
   - llm-tool
+created: 2026-04-30
+updated: 2026-04-30
+status: ingested
+title: "GitReverse"
 ---
 
 # GitReverse
 
 ## What It Is
 
-GitReverse takes a public GitHub repo URL and generates a synthetic user prompt — the kind of prompt someone might paste into Cursor, Claude Code, or Codex to "vibe code" the project from scratch.
+GitReverse takes a public GitHub repo URL and generates a synthetic user prompt — a prompt someone might paste into Cursor, Claude Code, or Codex to "vibe code" the project from scratch.
 
 ## How It Works
 

--- a/vault/wiki/sources/leanctx-website.md
+++ b/vault/wiki/sources/leanctx-website.md
@@ -12,6 +12,10 @@ key_claims:
   - "Supports 24 AI tools"
   - "Single Rust binary, zero telemetry, Apache 2.0"
   - "Agent governance with profiles, budgets, SLOs, anomaly detection"
+created: 2026-04-30
+updated: 2026-04-30
+status: ingested
+tags: [#source/website]
 ---
 
 # leanctx.com

--- a/vault/wiki/sources/openhands-platform.md
+++ b/vault/wiki/sources/openhands-platform.md
@@ -17,6 +17,8 @@ tags:
   - agent-platform
   - sandbox
   - multi-agent
+created: 2024-07-24
+updated: 2026-04-30
 ---
 
 # OpenHands: An Open Platform for AI Software Developers as Generalist Agents

--- a/vault/wiki/sources/oss-guide-codebase-exploration.md
+++ b/vault/wiki/sources/oss-guide-codebase-exploration.md
@@ -21,6 +21,8 @@ tags:
   - codebase-exploration
   - open-source
   - human-guide
+created: 2026-04-30
+updated: 2026-04-30
 ---
 
 # General Guide For Exploring Large Open Source Codebases

--- a/vault/wiki/sources/swe-agent-aci.md
+++ b/vault/wiki/sources/swe-agent-aci.md
@@ -18,6 +18,8 @@ tags:
   - swe-bench
   - agent-architecture
   - software-engineering
+created: 2024-05-06
+updated: 2026-04-30
 ---
 
 # SWE-agent: Agent-Computer Interfaces Enable Automated Software Engineering

--- a/vault/wiki/sources/swe-bench.md
+++ b/vault/wiki/sources/swe-bench.md
@@ -17,6 +17,8 @@ tags:
   - benchmark
   - software-engineering
   - evaluation
+created: 2023-10-10
+updated: 2026-04-30
 ---
 
 # SWE-bench: Can Language Models Resolve Real-World GitHub Issues?

--- a/vault/wiki/sources/think-in-code-blog.md
+++ b/vault/wiki/sources/think-in-code-blog.md
@@ -12,6 +12,10 @@ key_claims:
   - "47 files × Read() = 700 KB → 1 ctx_execute() = 3.6 KB (200× reduction)"
   - "Cloudflare uses similar 'Code Mode' for Workers API with 2,500+ endpoints"
   - "LLM writes TypeScript, code runs in sandbox, only console.log() output enters context"
+created: 2026-04-30
+updated: 2026-04-30
+status: ingested
+tags: [#source/blog]
 ---
 
 # Think in Code (blog post)

--- a/vault/wiki/sources/vgrep-semantic-search.md
+++ b/vault/wiki/sources/vgrep-semantic-search.md
@@ -20,6 +20,9 @@ tags:
 related:
   - "[[vgrep-tool]]"
   - "[[Research: semantic code search tools]]"
+created: 2026-04-30
+updated: 2026-04-30
+status: ingested
 ---
 
 # vgrep: Privacy-First Semantic Search Engine

--- a/vault/wiki/sources/wozcode.md
+++ b/vault/wiki/sources/wozcode.md
@@ -19,6 +19,10 @@ tags:
   - token-reduction
   - claude-code
   - agent-architecture
+created: 2026-04-30
+updated: 2026-04-30
+status: ingested
+title: "WOZCODE"
 ---
 
 # WOZCODE


### PR DESCRIPTION
- Closed 48 frontmatter gaps across all page types (type, title, created, updated, status, tags)
- Resolved 11 dead wikilinks: typo fixes, filename mismatches, new stub pages
- Created 11 stub pages for missing concepts/entities (agentic-harness, lean-ctx, context-mode, etc.)
- Fixed 1 style issue (weasel word in gitreverse source)
- Added lint report, dataview dashboard, and canvas map to wiki/meta
- 48 files changed, +507/-8