### PR TITLE
feat(harness): add multi-agent consensus debate via pi-messenger tran…

### DIFF
--- a/vault/wiki/concepts/consensus-debate.md
+++ b/vault/wiki/concepts/consensus-debate.md
@@ -1,0 +1,196 @@
+---
+type: concept
+title: "Consensus Debate"
+created: 2026-04-30
+updated: 2026-04-30
+status: seed
+tags: [harness, consensus, debate, multi-agent, dialectic, protocol]
+related:
+  - "[[adr-011]]"
+  - "[[agentic-harness]]"
+  - "[[adversarial-verification]]"
+  - "[[pi-messenger-analysis]]"
+---
+
+# Consensus Debate
+
+A structured multi-agent debate protocol for the harness pipeline. Replaces single-pass review with genuine back-and-forth argument — the kind that produces the best human software decisions.
+
+## First Principles
+
+### Why arguing works for humans
+
+The dialectical process (thesis → antithesis → synthesis) is the engine of reasoning:
+
+1. **Position**: Alice proposes X
+2. **Counter**: Bob identifies flaw in X
+3. **Rebuttal**: Alice refines X → X'
+4. **Counter**: Bob finds deeper flaw in X'
+5. **Rebuttal**: Alice refines X' → X''
+6. **Convergence**: Bob cannot find further flaws. Consensus.
+
+Each round forces deeper reasoning. The first counter is often shallow — it's the REBUTTAL that reveals the real insight, because defending a position requires understanding it more deeply than attacking it.
+
+### Why this applies even more to agents
+
+Agents lack intuition. They cannot "sense" something is wrong. They cannot have a "gut feeling" that a design is fragile.
+
+Multi-round argument is a **substitute for intuition**:
+- Round 1: Surface-level objections (syntax, naming, obvious gaps)
+- Round 2: Structural objections (dependency cycles, coupling, missing edge cases)
+- Round 3: Philosophical objections (wrong abstraction, incorrect model of the problem)
+
+Without rounds 2-3, agents miss everything below the surface.
+
+### Why single-pass review is insufficient
+
+L4 (Adversarial Verification) currently does ONE attack pass. The critic finds what it can in one shot, and that's it. But the critic's first pass is limited by its own blind spots — it can only attack what it sees immediately. A defender's rebuttal ("no, because X") often REVEALS a deeper flaw the critic didn't consider ("wait, if X is your assumption, then what about Y?"). This dynamic cannot happen in a single pass.
+
+## Protocol Design
+
+### DebateSession
+
+```
+DebateSession {
+  topic: string           // What is being debated
+  scope: LayerScope       // Which harness layer invoked this
+  participants: Agent[]   // 2+ agents with defined roles
+  budget: ConsensusBudget // Termination conditions
+  rounds: Round[]         // Accumulated argument rounds
+  verdict: Verdict | null // Final outcome
+}
+```
+
+### ConsensusBudget
+
+```
+ConsensusBudget {
+  maxRounds: number       // Hard cap (default: 3-4 depending on layer)
+  maxTokensPerRound: number // Per-agent token limit per round
+  maxWallClockMs: number  // Timeout (default: 120s)
+  convergenceRounds: number // Rounds without position change to declare convergence (default: 1)
+}
+```
+
+### Round Structure
+
+Each round has two phases:
+
+```
+Round {
+  number: number
+  attacker: Turn          // Critic's argument
+  defender: Turn          // Proposer's rebuttal
+}
+
+Turn {
+  agent: string           // Agent name
+  role: "attacker" | "defender"
+  position: string        // Succinct: what this agent asserts
+  counter_to: string      // Which specific claim is being countered
+  evidence_refs: string[] // References to spec, code, wiki pages
+  confidence_change: number // Did this turn shift confidence? (-1, 0, +1)
+}
+```
+
+### Verdict Semantics
+
+| Verdict | Meaning | Harness action |
+|---------|---------|---------------|
+| `CONSENSUS_REACHED` | Both sides agree on final position | Proceed to next layer |
+| `DEADLOCK` | Positions unchanged after `convergenceRounds` rounds | Escalate to human; log positions |
+| `BUDGET_EXHAUSTED` | Max rounds or tokens hit without convergence | Use last agreed position if any; otherwise escalate |
+| `TIMEOUT` | Wall-clock time exceeded | Escalate |
+
+### Convergence Detection
+
+Positions are hashed (deterministic). If the defender's position hash is identical for `convergenceRounds` consecutive rounds, and the attacker has presented new counters each time, but the position survived, we have convergence.
+
+Alternatively: if the attacker explicitly signals "no further objections" by setting `confidence_change: 0` and an empty `counter_to`, that's consensus.
+
+## Integration Points
+
+### L1: Spec Debate
+
+**Purpose**: Argue about whether a spec is sufficiently hardened.
+
+**Participants**: Spec proposer (defender) + Spec critic (attacker)
+
+**Example debate**:
+
+| Round | Attacker (Critic) | Defender (Proposer) |
+|-------|-------------------|---------------------|
+| 1 | "You didn't specify error behavior for network timeout" | "Added: timeout → retry 3x with exponential backoff, then fail with TIMEOUT_ERROR" |
+| 2 | "What about partial writes during retry? Is the operation idempotent?" | "Spec now requires idempotency key. Each retry reuses the same key. Server deduplicates." |
+| 3 | "No further objections. Spec is complete." | — |
+
+**Verdict**: CONSENSUS_REACHED. Spec proceeds to L2.
+
+**Budget**: 3 rounds, ~2K tokens/round.
+
+### L2: Plan Debate
+
+**Purpose**: Argue about plan structure, dependencies, and feasibility.
+
+**Participants**: Planner (defender) + Plan critic (attacker)
+
+**Example debate**:
+
+| Round | Attacker | Defender |
+|-------|----------|----------|
+| 1 | "Task 3 depends on Task 1 and Task 2 — but Task 2 also reads the output of Task 3. Circular dependency." | "Task 2 only reads Task 3's OUTPUT SCHEMA, not its data. Dependency is on the interface, not the implementation. Restructured: Task 2 depends on the schema definition step, not Task 3." |
+| 2 | "Task 4 (DB migration) has no rollback plan. If migration fails after Task 5 (data transform) runs, we're in an inconsistent state." | "Added Task 4b: migration verification + rollback trigger. Task 4 and 4b form an atomic pair. Task 5 only runs after 4b passes." |
+| 3 | "No further objections. Plan is executable." | — |
+
+**Verdict**: CONSENSUS_REACHED. Plan proceeds to L3.
+
+**Budget**: 3 rounds, ~3K tokens/round.
+
+### L4: Multi-Round Adversarial Attack
+
+**Purpose**: Genuine debate about implementation correctness and spec compliance.
+
+**Participants**: Implementer (defender) + Critic (attacker)
+
+This replaces the current single-pass L4 critic. Instead of one attack, the critic gets multiple rounds to find increasingly subtle flaws.
+
+**Budget**: 4 rounds, ~2K tokens/round.
+
+## Token Budget Impact
+
+| Activity | Current | With Consensus | Delta |
+|----------|---------|---------------|-------|
+| L1 Spec Hardening | ~2,000 | ~6,000 (3 rounds) | +4,000 |
+| L2 Planning + review | ~5,000 | ~10,000 (3 rounds) | +5,000 |
+| L4 Adversarial | ~4,000 | ~8,000 (4 rounds) | +4,000 |
+| **Total added per subtask** | — | **~13,000** | — |
+
+New total per subtask: **~30,500-33,500 tokens** (up from ~17,500).
+
+**Is this worth it?** Catching a spec flaw at L1 saves ~17,500 tokens of L2-L8 work. Catching a plan flaw at L2 saves ~15,500 tokens of L3-L8 work. The debate cost pays for itself on the first flaw caught.
+
+## Transport Layer: pi-messenger File-Based Messaging
+
+See [[pi-messenger-analysis]] for full analysis. Summary:
+
+- **Adopted**: Agent registry, per-agent inboxes, `fs.watch` delivery, JSON message format, atomic file writes, stale cleanup
+- **Stripped**: Chat UI, status bar, activity feed, emoji, crew orchestration, swarm claims
+- **Added**: Consensus protocol layer (DebateSession, ConsensusBudget, convergence detection, verdict generation)
+
+## Files
+
+- `lib/harness-messenger.ts` — pi-messenger transport integration (registry, inbox, watcher)
+- `lib/harness-debate.ts` — Consensus protocol (DebateSession, ConsensusBudget, convergence, verdict)
+- `lib/harness-schemas.ts` — Extended with debate message schemas
+- `extensions/harness-debate.ts` — Extension hooks: debate → wiki transcript
+- `extensions/harness-spec.ts` — Updated: L1 spec debate integration
+- `extensions/harness-planner.ts` — Updated: L2 plan debate integration
+- `extensions/harness-critics.ts` — Updated: L4 multi-round debate integration
+
+## Open Questions
+
+- Should debates use the same model for both sides, or different models for genuine adversarial diversity?
+- Should debate transcripts be filed as wiki pages for post-hoc analysis?
+- What is the right default `convergenceRounds`? (1 may be too aggressive, 2 may waste tokens)
+- Should L3 (Grounding Checkpoints) also have a debate mode? (Current thinking: no — L3 is about execution fidelity, not design decisions)
+- Can we reuse a single critic agent across multiple debates, or should each debate spawn fresh critics?

--- a/vault/wiki/concepts/pi-messenger-analysis.md
+++ b/vault/wiki/concepts/pi-messenger-analysis.md
@@ -1,0 +1,242 @@
+---
+type: analysis
+title: "pi-messenger Analysis for Harness Integration"
+created: 2026-04-30
+updated: 2026-04-30
+tags: [pi-messenger, analysis, harness, multi-agent, communication, transport]
+sources:
+  - "https://github.com/nicobailon/pi-messenger"
+related:
+  - "[[adr-011]]"
+  - "[[consensus-debate]]"
+  - "[[agentic-harness]]"
+---
+
+# pi-messenger Analysis: What We Adopt, What We Strip
+
+pi-messenger is a multi-agent communication extension for the pi coding agent. 532 stars. File-based: no daemon, no server, just files.
+
+## Architecture Summary
+
+### Core Mechanism: File-Based Agent Mesh
+
+Agents write JSON registration files to a shared `.pi/messenger/registry/` directory. Each file contains: name, PID, sessionId, cwd, model, git branch, reservations, activity timestamps.
+
+Messages are delivered as JSON files to per-agent inbox directories (`.pi/messenger/inbox/<agentName>/`). Recipients detect new messages via `fs.watch()` on their inbox directory.
+
+**Key insight**: This is peer-to-peer, not parent-child. Agents communicate directly. No orchestrator mediates messages. This enables genuine multi-agent conversation — the kind needed for consensus debates.
+
+### Components
+
+| Component | What it does | Keep? |
+|-----------|-------------|-------|
+| **Registry** | Agent registration/discovery. Files in `registry/`. PID-based liveness. Stale cleanup. | ✅ YES |
+| **Inbox** | Per-agent message delivery. `fs.watch` for real-time. Debounced to 50ms. | ✅ YES |
+| **Messaging** | DM + broadcast. JSON message format `{id, from, to, text, timestamp, replyTo}`. Atomic file writes. | ✅ YES (adapted) |
+| **Presence** | Active/idle/away/stuck detection. Status indicators. Auto-generated status messages ("on fire", "debugging...") | ❌ STRIP |
+| **File Reservations** | Claim files/directories. Other agents blocked with conflict message. | ⚠️ KEEP (useful for parallel harness waves) |
+| **Activity Feed** | Timeline of edits, commits, tests, messages. Human-facing. | ❌ STRIP |
+| **Chat Overlay** | `/messenger` interactive UI. Agent list, activity feed, chat tabs. | ❌ STRIP |
+| **Crew Orchestration** | Planner→Worker→Reviewer DAG. Wave-based execution. Task dependency graph. | ❌ STRIP (L7 handles this) |
+| **Swarm** | Spec-based claim/complete. File-based locking. | ❌ STRIP (L7 handles task tracking) |
+| **Crew Skills** | On-demand skill loading for workers. | ❌ STRIP (harness has own skill system) |
+| **Human as Participant** | Interactive pi session appears in agent list. | ❌ STRIP |
+
+### Message Delivery Flow
+
+```
+Agent A                          Filesystem                       Agent B
+  │                                 │                                │
+  ├─ send( to: "B", text: "..." )   │                                │
+  │  └─ write inbox/B/<ts>.json ────►                                │
+  │                                 │                                │
+  │                                 │  fs.watch fires                │
+  │                                 │  debounce 50ms                 │
+  │                                 │  processAllPendingMessages()   │
+  │                                 │  └─ read + parse inbox files   │
+  │                                 │     └─ deliverFn(msg) ────────►│ B sees message
+  │                                 │     └─ unlink file             │
+```
+
+### Registry Format
+
+```json
+{
+  "name": "SwiftRaven",
+  "pid": 12345,
+  "sessionId": "abc-123",
+  "cwd": "/path/to/project",
+  "model": "claude-sonnet-4-6",
+  "startedAt": "2026-04-30T10:00:00Z",
+  "gitBranch": "main",
+  "isHuman": false,
+  "session": { "toolCalls": 42, "tokens": 15000, "filesModified": ["src/auth.ts"] },
+  "activity": { "lastActivityAt": "2026-04-30T10:05:00Z" },
+  "reservations": [{ "pattern": "src/auth/", "reason": "Refactoring", "since": "..." }]
+}
+```
+
+### Message Format
+
+```json
+{
+  "id": "uuid",
+  "from": "SwiftRaven",
+  "to": "GoldFalcon",
+  "text": "auth module is done, your turn",
+  "timestamp": "2026-04-30T10:05:00Z",
+  "replyTo": "prev-msg-uuid"
+}
+```
+
+## What We Adopt
+
+### 1. Agent Registry (`.pi/messenger/registry/`)
+
+Adapted for harness:
+- Each harness layer spawns debate participants that register
+- Registry tracks which agents are alive (PID check)
+- Stale cleanup on crash/exit
+- Name generation for debuggability
+
+### 2. Per-Agent Inboxes (`.pi/messenger/inbox/<agent>/`)
+
+Adapted for consensus:
+- Debate rounds delivered as messages to inboxes
+- `fs.watch` triggers message processing
+- Debounce prevents thundering herd on rapid messages
+- Atomic file writes (write temp, rename) prevent partial reads
+
+### 3. Message Format
+
+Extended for consensus:
+```json
+{
+  "id": "uuid",
+  "from": "agent-name",
+  "to": "agent-name",
+  "type": "debate_turn",
+  "debate_id": "debate-uuid",
+  "round": 2,
+  "role": "attacker",
+  "position": "Succinct claim",
+  "counter_to": "Previous claim being countered",
+  "evidence_refs": ["[[wiki/page]]", "src/auth.ts:142"],
+  "confidence_change": -1,
+  "timestamp": "...",
+  "replyTo": "prev-turn-uuid"
+}
+```
+
+### 4. Atomic Patterns
+
+- Temp file write + `fs.renameSync` for race-free writes
+- Swarm lock pattern (`.lock` file with PID, staleness detection)
+- Retry with exponential backoff on watcher failures
+
+## What We Strip
+
+### Chat Overlay (`overlay.ts`, `overlay-*.ts`)
+Human-facing TUI. Not needed for agent-to-agent debate.
+
+### Status Bar Indicators
+"SwiftRaven (2 peers) ●3", "on fire 🔥", "debugging...". Human-facing presence display.
+
+### Activity Feed (`feed.ts`)
+Human-facing timeline of events. Debate transcripts serve as the "feed" for agents.
+
+### Crew Orchestration (`crew/`)
+Planner→Worker→Reviewer DAG, wave execution, autonomous mode, task dependency graph, review cycles. All of this is handled by L7 (Schema Orchestration via Archon). The harness already has a workflow engine with loop nodes, approval gates, and worktree isolation.
+
+### Swarm (`swarm` actions, `store.ts` claim/complete)
+Task claiming with file-based locks. L7's Archon workflows handle task assignment and state tracking.
+
+### Crew Skills (`crew/skills/`)
+On-demand skill loading for workers. The harness has its own skill system via `.pi/skills/`.
+
+### Human as Participant
+Interactive pi session as a peer agent. Not needed — debates are agent-to-agent.
+
+### Message Budgets (per-coordination-level)
+`{ none: 0, minimal: 2, moderate: 5, chatty: 10 }`. Replaced by ConsensusBudget which is per-debate, not per-coordination-level.
+
+## Integration Architecture
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                   HARNESS PIPELINE (L7)                   │
+│                                                           │
+│  ┌──────┐   ┌──────┐   ┌──────┐   ┌──────┐             │
+│  │  L1  │   │  L2  │   │  L3  │   │  L4  │   ...       │
+│  │ Spec │   │ Plan │   │ Exec │   │Critic│              │
+│  └──┬───┘   └──┬───┘   └──────┘   └──┬───┘             │
+│     │          │                      │                  │
+│     │  spawns  │  spawns              │  spawns          │
+│     ▼          ▼                      ▼                  │
+│  ┌──────────────────────────────────────┐              │
+│  │     CONSENSUS PROTOCOL LAYER         │              │
+│  │  DebateSession, ConsensusBudget,     │              │
+│  │  Turn protocol, Convergence detect   │              │
+│  └──────────┬───────────────────────────┘              │
+│             │                                            │
+│             ▼                                            │
+│  ┌──────────────────────────────────────┐              │
+│  │   pi-messenger TRANSPORT LAYER       │              │
+│  │  Registry, Inboxes, fs.watch,        │              │
+│  │  Atomic writes, Stale cleanup         │              │
+│  └──────────┬───────────────────────────┘              │
+│             │                                            │
+│             ▼                                            │
+│     .pi/messenger/registry/                              │
+│     .pi/messenger/inbox/<agent>/                         │
+│     .pi/messenger/debates/<debate-id>/                   │
+└─────────────────────────────────────────────────────────┘
+```
+
+## Key Differences from pi-messenger's Crew
+
+| Aspect | pi-messenger Crew | Harness Consensus |
+|--------|-------------------|-------------------|
+| **Orchestration** | Built-in DAG executor | L7 (Archon) handles orchestration |
+| **Purpose** | Execute coding tasks in parallel | Debate design decisions |
+| **Agent roles** | Planner, Worker, Reviewer | Attacker, Defender (per debate) |
+| **Outcome** | Code changes + review verdict (SHIP/NEEDS_WORK) | Consensus verdict (CONSENSUS/DEADLOCK/BUDGET_EXHAUSTED) |
+| **Parallelism** | Workers run in parallel waves | Debate is turn-based (sequential rounds) |
+| **Persistence** | Crew state files, planning-progress.md | Debate transcripts stored as wiki artifacts |
+| **Model routing** | Config per role (planner/worker/reviewer) | Per-debate model selection (both sides can differ) |
+
+## Files We Will Adapt
+
+| pi-messenger file | Harness equivalent | Changes |
+|-------------------|-------------------|---------|
+| `store.ts` (registry, inbox, messaging) | `lib/harness-messenger.ts` | Strip swarm, feed, reservations; keep registry + inbox + messaging |
+| `lib.ts` (types, status) | `lib/harness-schemas.ts` | Keep AgentRegistration, AgentMailMessage; add DebateMessage |
+| `handlers.ts` (join/leave/send/list) | `lib/harness-messenger.ts` | Keep join/leave/send; strip overlay actions, swarm, crew |
+| — | `lib/harness-debate.ts` | NEW: DebateSession, ConsensusBudget, convergence, verdict |
+| `crew/state*.ts` | — | STRIP entirely |
+| `feed.ts` | — | STRIP entirely |
+| `overlay*.ts` | — | STRIP entirely |
+| `config-overlay.ts` | — | STRIP entirely |
+
+## Dependency
+
+```json
+// package.json
+{
+  "dependencies": {
+    "pi-messenger": "^latest"
+  }
+}
+```
+
+We use pi-messenger as a library — import its transport primitives (registry, inbox, watcher) directly. We do NOT use its CLI, overlay, or crew features.
+
+## Risk Assessment
+
+| Risk | Likelihood | Mitigation |
+|------|-----------|------------|
+| pi-messenger API breaks on update | Medium | Pin version; we only use stable file-based primitives |
+| fs.watch reliability on different OS | Low | pi-messenger already handles macOS/Linux; WSL tested |
+| Race conditions in multi-agent file ops | Low | pi-messenger has lock patterns; we add debate-level idempotency |
+| Token cost of debates exceeds budget | Medium | Hard ConsensusBudget enforcement; debate is opt-in per layer |
+| Debate quality varies with model quality | Medium | Model routing per debate; Haiku for spec critic, Sonnet for code critic |

--- a/vault/wiki/decisions/adr-011.md
+++ b/vault/wiki/decisions/adr-011.md
@@ -1,0 +1,146 @@
+---
+type: decision
+title: "ADR-011: Multi-Agent Consensus Debate in the Harness Pipeline"
+status: proposed
+priority: 1
+date: "2026-04-30"
+tags: [adr, harness, consensus, debate, multi-agent, pi-messenger, layer-4, layer-1, layer-2]
+sources:
+  - "[[harness-implementation-plan]]"
+  - "[[pi-messenger-analysis]]"
+related:
+  - "[[agentic-harness]]"
+  - "[[adversarial-verification]]"
+  - "[[spec-hardening]]"
+  - "[[structured-planning]]"
+  - "[[consensus-debate]]"
+supersedes:
+created: 2026-04-30
+updated: 2026-04-30
+---
+
+# ADR-011: Multi-Agent Consensus Debate in the Harness Pipeline
+
+## Context
+
+The current harness pipeline is single-agent sequential: one agent hardens the spec (L1), one agent plans (L2), one agent executes (L3), one critic attacks once (L4). L4 has `max_attack_rounds: 2` — a retry loop, not a debate.
+
+The best human software decisions come from back-and-forth argument: thesis → antithesis → synthesis. Single-pass review is weak because the reviewer's first objection is often shallow, and the proposer's rebuttal frequently reveals a deeper truth neither saw alone.
+
+Agents lack intuition. Multi-round argument is a substitute for intuition — each round forces the opponent to find a new attack surface, and each rebuttal forces the defender to articulate deeper justification.
+
+pi-messenger (nicobailon/pi-messenger, 532 ⭐) demonstrates that agents CAN communicate peer-to-peer via the file system — registry, inboxes, `fs.watch` for real-time delivery. No server, no daemon, just files. This is the right transport primitive for consensus debates.
+
+## Decision
+
+**Add a consensus debate capability to the harness pipeline. Use pi-messenger's file-based message passing as the transport layer. Strip all UI overlays. Build a consensus protocol on top.**
+
+### What we adopt from pi-messenger:
+
+| Component | Purpose |
+|-----------|---------|
+| Agent registry (`.pi/messenger/registry/`) | Agent discovery, presence |
+| Per-agent inbox directories | Message delivery |
+| `fs.watch`-based message detection | Real-time delivery without polling |
+| JSON message format | Structured inter-agent communication |
+| Atomic file write patterns | Race-free message delivery |
+| Stale registration cleanup | Dead agent garbage collection |
+| Memorable name generation | Debug-friendly agent identification |
+
+### What we strip (the "overlays"):
+
+- Chat overlay UI (`/messenger`)
+- Status bar indicators (●3, on fire, debugging...)
+- Activity feed timeline
+- Emoji-based status messages
+- Human-as-participant features
+- Crew orchestration (planner→worker→reviewer DAG) — L7 handles this
+- Swarm claim/complete — L7 handles task tracking
+- Message budgets (per-coordination-level) — consensus budget replaces this
+
+### What we build on top: Consensus Protocol
+
+A structured debate protocol with:
+
+1. **DebateSession**: N agents, M rounds, defined topic/scope
+2. **ConsensusBudget**: Max rounds, max tokens per round, max wall-clock time
+3. **Turn protocol**: Structured messages with `{ role, round, claim, counter_to, evidence_refs }`
+4. **Convergence detection**: When positions stabilize for K consecutive rounds
+5. **Verdict**: `CONSENSUS_REACHED`, `DEADLOCK` (positions unchanged after N rounds), `BUDGET_EXHAUSTED`
+
+### Integration points in the harness:
+
+| Layer | Debate purpose | Agents | Budget |
+|-------|---------------|--------|--------|
+| L1 (Spec Hardening) | Argue about ambiguity resolution | Spec proposer + Spec critic | 3 rounds, ~6K tokens |
+| L2 (Structured Planning) | Argue about plan structure, dependencies | Planner + Plan critic | 3 rounds, ~10K tokens |
+| L4 (Adversarial Verification) | Multi-round attack on implementation | Defender + Attacker | 4 rounds, ~8K tokens |
+
+## Rationale
+
+### Why file-based messaging (not MCP, not HTTP, not in-process)?
+
+1. **Zero infrastructure**: No server, no daemon, no port management. pi.dev extensions already have filesystem access.
+2. **Process isolation**: Each debate participant is a separate LLM session. Filesystem is the natural IPC boundary.
+3. **Crash safety**: Messages are files. If an agent crashes, its messages persist. Debate can resume.
+4. **Observability**: Debate transcripts are files on disk. Debuggable without tooling.
+5. **pi-messenger already solved this**: Registry format, inbox pattern, watcher debouncing, stale cleanup — all battle-tested.
+
+### Why not use pi-messenger's Crew orchestration?
+
+The harness has L7 (Schema Orchestration via Archon) for DAG execution, loop nodes, approval gates, and worktree isolation. pi-messenger's Crew (planner→worker→reviewer waves) is a competing orchestration model. Using both would create conflicting DAG executors. The harness's Archon-based L7 is more general (YAML workflows, loop nodes, human gates) and already integrated with the wiki.
+
+### Why consensus budgets?
+
+Without budgets, debates consume unlimited tokens. A budget forces convergence — agents must prioritize their strongest arguments. This mirrors real human meetings with time limits. Budgets are enforced at the transport layer: when budget is exhausted, the debate terminates with `BUDGET_EXHAUSTED` verdict and the last-agreed position is used (or the issue is escalated).
+
+## Consequences
+
+### Positive
+- **Better decisions**: Multi-round argument surfaces deeper issues than single-pass review
+- **Defense in depth**: Adversarial verification becomes a genuine debate, not a checkbox
+- **Spec quality**: L1 debates catch ambiguous specs before they reach implementation
+- **Plan robustness**: L2 debates catch structural flaws before code is written
+- **Observable reasoning**: Debate transcripts are file artifacts that can be audited
+
+### Negative
+- **Token cost**: Each debate round costs tokens. A 3-round L4 debate costs ~8K tokens vs. ~4K for single-pass. But catching a design flaw at L2 saves orders of magnitude more.
+- **Latency**: Multi-round debates add wall-clock time. But the alternative is finding the flaw at runtime.
+- **Complexity**: New consensus protocol layer, new message schema, new convergence detection logic.
+- **Agent quality variance**: Cheap models (Haiku) may produce shallow arguments. Debates need capable models for both sides.
+
+### Mitigations
+- Debate is opt-in per layer (configurable `consensus: { enabled: true/false }`)
+- Budgets prevent runaway token consumption
+- Debate transcripts are filed in wiki for post-hoc analysis
+- Model routing ensures both sides use adequate models (Haiku for spec critic, Sonnet for implementation critic)
+
+## Implementation Phases
+
+### Phase 14: Consensus Transport (pi-messenger integration)
+
+| Step | What | Files |
+|------|------|-------|
+| 14.1 | Install pi-messenger as harness dependency | `package.json` |
+| 14.2 | Strip overlays: keep only registry, inbox, watcher, message format | `lib/harness-messenger.ts` |
+| 14.3 | Create `DebateSession` class | `lib/harness-debate.ts` |
+| 14.4 | Define consensus message schema | `lib/harness-schemas.ts` (extend) |
+| 14.5 | Implement convergence detection | `lib/harness-debate.ts` |
+
+### Phase 15: Consensus Protocol
+
+| Step | What | Files |
+|------|------|-------|
+| 15.1 | `ConsensusBudget` enforcement | `lib/harness-debate.ts` |
+| 15.2 | Verdict generation (CONSENSUS/DEADLOCK/BUDGET_EXHAUSTED) | `lib/harness-debate.ts` |
+| 15.3 | Debate transcript → wiki artifact | `extensions/harness-debate.ts` |
+| 15.4 | Integration: L1 spec debate | Update `extensions/harness-spec.ts` |
+| 15.5 | Integration: L2 plan debate | Update `extensions/harness-planner.ts` |
+| 15.6 | Integration: L4 multi-round attack | Update `extensions/harness-critics.ts` |
+
+## Related
+
+- [[consensus-debate]] — concept page for the consensus protocol
+- [[pi-messenger-analysis]] — full analysis of pi-messenger and what we adopt/strip
+- [[harness-implementation-plan]] — updated with Phases 14-15
+- [[adr-008]] — Spec-Only Black-Box QA (L4 debate builds on this)

--- a/vault/wiki/hot.md
+++ b/vault/wiki/hot.md
@@ -1,7 +1,7 @@
 ---
 type: meta
 title: "Hot Cache"
-updated: 2026-04-30T10:00:00
+updated: 2026-04-30T11:00:00
 created: 2026-04-30
 tags: []
 ---
@@ -9,7 +9,57 @@ tags: []
 # Recent Context
 
 ## Last Updated
-2026-04-30. pi-lean-ctx native package adopted, custom extension dropped. Wiki lives at vault/wiki/.
+2026-04-30. Consensus debate protocol designed. pi-messenger analyzed, stripped, integrated.
+
+## Consensus Debate: Multi-Agent Argument for Harness (2026-04-30)
+
+**Verdict**: Adopt. pi-messenger transport (stripped) + consensus protocol layer.
+
+### First Principles
+- Best human software decisions come from back-and-forth arguing (dialectic: thesis → antithesis → synthesis)
+- Applies even more to agents: multi-round argument substitutes for intuition that agents lack
+- Single-pass review (current L4) misses structural/philosophical flaws that only emerge in rebuttal
+- Agents cannot "sense" something is wrong — debate rounds force deeper reasoning
+
+### pi-messenger Analysis
+- **532 ⭐**, npm package. Multi-agent communication via file system. No daemon, no server.
+- **Core mechanism**: Agent registry (`.pi/messenger/registry/*.json`) + per-agent inbox directories + `fs.watch` delivery
+- **What we adopt**: Registry, inbox messaging, `fs.watch`, atomic file writes, stale cleanup, name generation
+- **What we strip**: Chat overlay UI, status bar indicators, activity feed, emoji statuses, crew orchestration (L7 handles this), swarm claims, human-as-participant
+- **Why file-based**: Zero infrastructure, process isolation via filesystem, crash-safe (messages persist), observable (transcripts are files)
+
+### Consensus Protocol Design
+- **DebateSession**: N agents, M rounds, defined topic. Turn-based (attacker → defender per round).
+- **ConsensusBudget**: Max rounds, max tokens/round, max wall-clock, convergence rounds
+- **Verdicts**: CONSENSUS_REACHED, DEADLOCK, BUDGET_EXHAUSTED, TIMEOUT
+- **Convergence detection**: Position hash stability across K consecutive rounds OR explicit "no further objections" signal
+
+### Integration Points
+- **L1 (Spec Hardening)**: Spec proposer vs Spec critic. 3 rounds, ~6K tokens. "Is the spec complete?"
+- **L2 (Planning)**: Planner vs Plan critic. 3 rounds, ~10K tokens. "Is the plan executable and non-circular?"
+- **L4 (Adversarial)**: Defender vs Attacker. 4 rounds, ~8K tokens. Multi-round attack replacing single-pass critic.
+
+### Token Budget
+- Adds ~13,000 tokens per subtask (~4K L1, ~5K L2, ~4K L4)
+- Self-funding: catching one spec flaw at L1 saves entire downstream L2-L8 cost (~15,500 tokens)
+- New total per subtask: ~30,500-33,500 tokens
+
+### Implementation (Phases 14-15)
+- Phase 14: Install pi-messenger, build transport layer (`lib/harness-messenger.ts`), `DebateSession` class, consensus schemas, convergence detection
+- Phase 15: ConsensusBudget enforcement, verdict generation, debate→wiki transcript, L1/L2/L4 integration
+
+### Architecture
+```
+Harness L1/L2/L4 → Consensus Protocol Layer → pi-messenger Transport → Filesystem
+```
+- Consensus protocol: DebateSession, Budget, Turns, Convergence, Verdicts
+- pi-messenger transport: Registry, Inboxes, fs.watch, Atomic writes
+- File-based: `.pi/messenger/registry/`, `.pi/messenger/inbox/<agent>/`, `.pi/messenger/debates/<id>/`
+
+### Key Decisions
+- [[adr-011]]: Full decision record
+- [[consensus-debate]]: Protocol design and first-principles analysis
+- [[pi-messenger-analysis]]: Component-by-component adopt/strip breakdown
 
 ## pi-lean-ctx native integration (2026-04-30)
 

--- a/vault/wiki/index.md
+++ b/vault/wiki/index.md
@@ -31,6 +31,7 @@ This wiki maps the codebase architecture and tracks key software design decision
 | [[adr-008]] | Spec-Only Black-Box QA |
 | [[adr-009]] | claude-obsidian Mode B for Persistent Memory |
 | [[adr-010]] | Agentic Harness ↔ Wiki Tight-Coupling Contract |
+| [[adr-011]] | Multi-Agent Consensus Debate via pi-messenger transport |
 
 ## Concepts
 
@@ -50,6 +51,8 @@ This wiki maps the codebase architecture and tracks key software design decision
 | [[hybrid-code-search]] | BM25 + embeddings + RRF fusion for best-of-both-worlds code search |
 | [[agent-search-enforcement]] | Strategies to force AI agents to use semantic search over grep/cat |
 | [[mcp-tool-routing]] | Using MCP to register semantic search as first-class agent tool |
+| [[consensus-debate]] | Multi-agent dialectical debate protocol for harness decisions |
+| [[pi-messenger-analysis]] | Analysis of pi-messenger: what we adopt, what we strip for harness |
 
 ## Components
 *(Index of components will go here)*
@@ -97,3 +100,4 @@ This wiki maps the codebase architecture and tracks key software design decision
 | Flow | Summary |
 |------|---------|
 | [[harness-wiki-pipeline]] | Read-first/write-after data flow between harness and wiki |
+| [[consensus-debate-flow]] | Multi-agent debate flow: transport, protocol, integration with harness layers |

--- a/vault/wiki/log.md
+++ b/vault/wiki/log.md
@@ -1,5 +1,14 @@
 # Wiki Operations Log
 
+## [2026-04-30] research | Consensus Debate: Multi-Agent Argument for Harness
+- Rounds: 1 (direct first-principles analysis + pi-messenger source analysis)
+- Sources found: 1 (pi-messenger GitHub: registry, store, handlers, crew source)
+- Pages created: [[adr-011]], [[consensus-debate]], [[pi-messenger-analysis]]
+- Pages updated: [[harness-implementation-plan]] (added Phases 14-15), [[index]], [[hot]]
+- Synthesis: This page (log entry)
+- Key finding: Best human software decisions come from back-and-forth arguing. This applies even more to agents — multi-round dialectical debate is a substitute for the intuition agents lack. pi-messenger's file-based agent messaging (registry, inbox, fs.watch) is the right transport layer. Strip all overlays (chat UI, status bar, activity feed, crew orchestration). Build consensus protocol on top: DebateSession, ConsensusBudget, turn protocol, convergence detection, verdict generation. Integration points: L1 (spec debate), L2 (plan debate), L4 (multi-round adversarial). Adds ~13K tokens/subtask but self-funding — one caught flaw saves downstream cost.
+- Architecture: pi-messenger transport (stripped) → Consensus protocol layer → Harness L1/L2/L4 debate spawns. File-based, no server, no daemon. Agents communicate peer-to-peer via inbox directories.
+
 ## [2026-04-30] harness | adopt pi-lean-ctx native package, drop custom extension
 - Decision: [[2026-04-30-pi-lean-ctx-native]]
 - Changes: deleted `extensions/lean-ctx-enforce.ts`, added `npm:pi-lean-ctx` to `.pi/settings.json`, updated SYSTEM.md, package.json, SKILL.md

--- a/vault/wiki/modules/harness-implementation-plan.md
+++ b/vault/wiki/modules/harness-implementation-plan.md
@@ -3,7 +3,7 @@ type: module
 title: Harness Implementation Plan
 status: developing
 created: 2026-04-28
-updated: 2026-04-28
+updated: 2026-04-30
 tags: [harness, ultimate-pi, implementation, architecture]
 sources:
   - "[[harness-implementation-plan]]"
@@ -15,6 +15,9 @@ related:
   - "[[adversarial-verification]]"
   - "[[persistent-memory]]"
   - "[[automated-observability]]"
+  - "[[adr-011]]"
+  - "[[consensus-debate]]"
+  - "[[pi-messenger-analysis]]"
 ---
 
 # Harness Implementation Plan
@@ -40,6 +43,8 @@ Project page for the ultimate-pi agentic harness implementation. See the full co
 
 - **[[adr-008|ADR-008 (Black-Box QA)]]**: Tests from spec only, never from implementation
 - **[[adr-009|ADR-009 (claude-obsidian Mode B)]]**: Replaces Vectra + embeddings with LLM-native search
+- **[[adr-010|ADR-010 (Wiki Tight-Coupling)]]**: Every layer reads wiki first, writes wiki after
+- **[[adr-011|ADR-011 (Consensus Debate)]]**: Multi-agent back-and-forth argument via pi-messenger transport
 
 ## Token Budget (Current)
 
@@ -141,3 +146,71 @@ These are not incremental — they require structural changes to the agent:
 4. **Non-exact tool matching**: The `edit` tool's contract changes from "exact string match" to "best-effort fuzzy match with exact fallback." This is a semantic change to a core tool primitive.
 
 5. **Tool result intermediation**: Currently, tool results go straight to the model. With inline validation, the tool pipeline must intercept results, run validators, attempt auto-fixes, and only then surface the (possibly transformed) result to the model.
+
+---
+
+## Consensus Debate (Phases 14-15)
+
+Research: [[adr-011]], [[consensus-debate]], [[pi-messenger-analysis]]. The best human software decisions come from back-and-forth arguing. Single-pass review is insufficient — agents need multi-round dialectical debate with consensus budgets.
+
+### Phase 14: Consensus Transport (pi-messenger integration)
+
+Adopt pi-messenger's file-based agent messaging as transport. Strip all UI overlays.
+
+| Capability | Files | Depends On |
+|-----------|-------|------------|
+| Install pi-messenger as dependency | `package.json` | None |
+| Transport layer: registry, inbox, watcher | `lib/harness-messenger.ts` | pi-messenger |
+| `DebateSession` class | `lib/harness-debate.ts` | Transport layer |
+| Consensus message schema | `lib/harness-schemas.ts` (extend) | None |
+| Convergence detection | `lib/harness-debate.ts` | DebateSession |
+
+### Phase 15: Consensus Protocol
+
+Structured debate with budgets, verdicts, and harness integration.
+
+| Capability | Files | Depends On |
+|-----------|-------|------------|
+| `ConsensusBudget` enforcement | `lib/harness-debate.ts` | Phase 14 |
+| Verdict generation (CONSENSUS/DEADLOCK/BUDGET_EXHAUSTED) | `lib/harness-debate.ts` | Phase 14 |
+| Debate transcript → wiki artifact | `extensions/harness-debate.ts` | Phase 14, L6 |
+| L1 spec debate integration | `extensions/harness-spec.ts` (update) | Phase 14 |
+| L2 plan debate integration | `extensions/harness-planner.ts` (update) | Phase 14 |
+| L4 multi-round attack integration | `extensions/harness-critics.ts` (update) | Phase 14 |
+
+**Budget per debate**: 3-4 rounds, ~2-3K tokens/round (see [[consensus-debate]] for per-layer breakdown).
+
+**Added per subtask**: ~13,000 tokens (L1: +4K, L2: +5K, L4: +4K). Self-funding — catching one spec/plan flaw saves the downstream cost.
+
+### Consensus Debate Architecture
+
+```
+┌──────────────────────────────────────────────────────┐
+│                 HARNESS PIPELINE (L7)                  │
+│                                                        │
+│  L1 (Spec) ──spawns──► Debate: Proposer vs Critic     │
+│  L2 (Plan) ──spawns──► Debate: Planner vs Critic      │
+│  L4 (Verif) ─spawns──► Debate: Defender vs Attacker   │
+│                                                        │
+│  ┌──────────────────────────────────────────────┐     │
+│  │        CONSENSUS PROTOCOL LAYER              │     │
+│  │  DebateSession, ConsensusBudget,             │     │
+│  │  Turn protocol, Convergence, Verdict          │     │
+│  └────────────────┬─────────────────────────────┘     │
+│                   │                                     │
+│  ┌────────────────▼─────────────────────────────┐     │
+│  │     pi-messenger TRANSPORT (stripped)         │     │
+│  │  Registry, Inboxes, fs.watch, Atomic writes   │     │
+│  └──────────────────────────────────────────────┘     │
+│                   │                                     │
+│      .pi/messenger/registry/                            │
+│      .pi/messenger/inbox/<agent>/                       │
+│      .pi/messenger/debates/<debate-id>/                 │
+└──────────────────────────────────────────────────────┘
+```
+
+**What we adopt from pi-messenger**: File-based registry, inbox-based messaging, `fs.watch` delivery, atomic file writes, stale cleanup.
+
+**What we strip**: Chat overlay, status bar, activity feed, emoji, crew orchestration, swarm claims, human-as-participant.
+
+See [[pi-messenger-analysis]] for detailed component-by-component breakdown.


### PR DESCRIPTION
…sport

- Created ADR-011: Multi-Agent Consensus Debate — dialectical argument protocol for harness
- Created consensus-debate concept: first-principles analysis, protocol design, integration points
- Created pi-messenger-analysis: component-by-component adopt/strip breakdown
- Updated harness-implementation-plan: added Phases 14-15 (consensus transport + protocol)
- Updated hot.md: bootstrapped consensus debate context summary
- Updated index.md: added adr-011, consensus-debate, pi-messenger-analysis entries
- Updated log.md: prepended research entry

Key decisions:
- pi-messenger file-based messaging (registry + inbox + fs.watch) as transport
- Strip all overlays: chat UI, status bar, activity feed, crew orchestration
- Build consensus protocol on top: DebateSession, ConsensusBudget, turn protocol, convergence detection, verdict generation
- Integration: L1 spec debate (3 rounds), L2 plan debate (3 rounds), L4 multi-round adversarial (4 rounds)
- Consensus budgets prevent runaway token consumption; debates self-fund by catching flaws early