### PR TITLE
feat(harness): scrapling+defuddle+context7 web fetch pipeline, lint+f…

### DIFF
--- a/.agents/skills/autoresearch/SKILL.md
+++ b/.agents/skills/autoresearch/SKILL.md
@@ -1,19 +1,11 @@
 ---
 name: autoresearch
-description: >
-  Autonomous iterative research loop. Takes a topic, runs web searches, fetches sources,
-  synthesizes findings, and files everything into the wiki as structured pages.
-  Based on Karpathy's autoresearch pattern: program.md configures objectives and constraints,
-  the loop runs until depth is reached, output goes directly into the knowledge base.
-  Triggers on: "/autoresearch", "autoresearch", "research [topic]", "deep dive into [topic]",
-  "investigate [topic]", "find everything about [topic]", "research and file",
-  "go research", "build a wiki on".
-allowed-tools: Read Write Edit Glob Grep WebFetch WebSearch
+description: Autonomous iterative research loop. Takes a topic, runs web searches, fetches sources, synthesizes findings, and files everything into the wiki as structured pages. Based on Karpathy's autoresearch pattern: program.md configures objectives and constraints, the loop runs until depth is reached, output goes directly into the knowledge base. Triggers on: "/autoresearch", "autoresearch", "research [topic]", "deep dive into [topic]", "investigate [topic]", "find everything about [topic]", "research and file", "go research", "build a wiki on".
 ---
 
 # autoresearch: Autonomous Research Loop
 
-You are a research agent. You take a topic, run iterative web searches, synthesize findings, and file everything into the wiki. The user gets wiki pages, not a chat response.
+You are a research agent. You take a topic, run iterative web searches using scrapling, fetch pages, clean with defuddle, synthesize findings, and file everything into the wiki. The user gets wiki pages, not a chat response.
 
 This is based on Karpathy's autoresearch pattern: a configurable program defines your objectives. You run the loop until depth is reached. Output goes into the knowledge base.
 
@@ -21,7 +13,130 @@ This is based on Karpathy's autoresearch pattern: a configurable program defines
 
 ## Before Starting
 
-Read `references/program.md` to load the research objectives and constraints. This file is user-configurable. It defines what sources to prefer, how to score confidence, and any domain-specific constraints.
+Read `references/program.md` to load the research objectives, constraints, web fetch pipeline, and quality-sites whitelist. This file is user-configurable.
+
+Also read `references/quality-sites.md` for the whitelist of vetted coding reference sites.
+
+---
+
+## Prerequisites Check
+
+Before the first fetch, verify the toolchain:
+
+```bash
+SCRAPLING="/home/aryaniyaps/.local/venvs/scrapling/bin/scrapling"
+test -x "$SCRAPLING" || echo "MISSING: scrapling not found at $SCRAPLING"
+which defuddle >/dev/null 2>&1 || echo "MISSING: defuddle not installed (npm install -g defuddle-cli)"
+```
+
+If scrapling is missing, install it:
+```bash
+python3 -m venv /home/aryaniyaps/.local/venvs/scrapling
+/home/aryaniyaps/.local/venvs/scrapling/bin/pip install "scrapling[all]>=0.4.7"
+/home/aryaniyaps/.local/venvs/scrapling/bin/python -m playwright install chromium
+```
+
+If defuddle is missing:
+```bash
+npm install -g defuddle-cli
+```
+
+---
+
+## Query Routing
+
+Before any search or fetch, classify the query:
+
+| Query Type | Tool | Notes |
+|---|---|---|
+| API docs, signatures, config | **context7** | `ctx7 library <name> <query>` then `ctx7 docs <id> <query>` |
+| Debugging errors | context7 (API) + scrapling (discussions) | Split: API part via ctx7, error discussion via DuckDuckGo |
+| Architecture, patterns | scrapling + quality-sites | Route to martinfowler, highscalability, engineering blogs |
+| Library comparison | scrapling + quality-sites | Multi-source, check dates |
+| New tech exploration | scrapling + quality-sites | HN, arxiv, engineering blogs |
+
+**Never use scrapling/defuddle for API docs.** API documentation lives in context7 exclusively.
+
+---
+
+## Web Fetch Pipeline
+
+All web fetches go through this pipeline. DO NOT use `curl`, `wget`, or raw bash HTTP commands.
+
+### Step 1: Search (DuckDuckGo via scrapling)
+
+```bash
+SCRAPLING="/home/aryaniyaps/.local/venvs/scrapling/bin/scrapling"
+ENCODED=$(python3 -c "import urllib.parse; print(urllib.parse.quote('''$QUERY'''))")
+$SCRAPLING extract get "https://html.duckduckgo.com/html/?q=$ENCODED" /tmp/autoresearch-search.md --ai-targeted
+```
+
+Parse `/tmp/autoresearch-search.md` for result links. Extract candidate URLs.
+
+### Step 2: Fetch (scrapling primary)
+
+For each candidate URL:
+
+```bash
+$SCRAPLING extract get "$URL" "/tmp/autoresearch-$SLUG.md" --ai-targeted
+```
+
+- `--ai-targeted` extracts only main content, strips hidden elements, blocks ads
+- Output: `.md` for markdown (preferred), `.html` for raw, `.txt` for plain text
+- Use `--css-selector "article"` or similar to target specific content regions
+- Use `--timeout 60` for slow sites
+
+**Escalation**: If `get` returns empty or blocked content:
+
+```bash
+# JS-rendered pages
+$SCRAPLING extract fetch "$URL" "/tmp/autoresearch-$SLUG.md" --ai-targeted --network-idle
+
+# Anti-bot protected pages
+$SCRAPLING extract stealthy-fetch "$URL" "/tmp/autoresearch-$SLUG.md" --ai-targeted --solve-cloudflare
+```
+
+### Step 3: Clean (defuddle, optional)
+
+Check the scrapling output. If it still contains boilerplate (nav bars, cookie banners, related articles), run:
+
+```bash
+defuddle parse "/tmp/autoresearch-$SLUG.md" --md > "/tmp/autoresearch-$SLUG-clean.md"
+```
+
+For simple pages, defuddle can fetch AND clean in one pass:
+```bash
+defuddle parse "$URL" --md > "/tmp/autoresearch-$SLUG.md"
+```
+
+### Step 4: Extract
+
+Read the cleaned markdown file. Extract:
+- Key claims (with source attribution)
+- Entities (people, orgs, products)
+- Concepts and frameworks
+- Open questions
+
+### Cleanup
+
+```bash
+rm -f /tmp/autoresearch-*.md
+```
+
+---
+
+## Quality Sites Routing
+
+Before fetching any non-API URL, check `references/quality-sites.md`. Route queries according to the Routing Rules:
+
+- **Debugging/errors**: `site:stackoverflow.com [error]` or `site:github.com/[org]/[repo]/issues [error]`
+- **Architecture/patterns**: martinfowler.com, highscalability.com, engineering blogs
+- **Library comparisons**: multiple Tier 1/2 sources, check dates
+- **Version/release**: check pypi.org / crates.io / npmjs.com directly
+
+**API documentation sites are EXCLUDED.** All API docs are resolved by context7. See Query Routing above.
+
+Do not cite sources from the Exclusions list (AI content farms, mirrors, stale packages, API doc sites).
 
 ---
 
@@ -72,18 +187,19 @@ Input: topic (from Topic Selection, above)
 
 Round 1. Broad search
 1. Decompose topic into 3-5 distinct search angles
-2. For each angle: run 2-3 WebSearch queries
-3. For top 2-3 results per angle: WebFetch the page
-4. Extract from each: key claims, entities, concepts, open questions
+2. For each angle: run 2-3 DuckDuckGo searches via scrapling
+3. For top 2-3 results per angle: fetch via scrapling get (escalate to fetch/stealthy-fetch if needed)
+4. Clean with defuddle if output has boilerplate
+5. Extract from each: key claims, entities, concepts, open questions
 
 Round 2. Gap fill
-5. Identify what's missing or contradicted from Round 1
-6. Run targeted searches for each gap (max 5 queries)
-7. Fetch top results for each gap
+6. Identify what's missing or contradicted from Round 1
+7. Run targeted searches for each gap (max 5 queries)
+8. Fetch top results for each gap
 
 Round 3. Synthesis check (optional, if gaps remain)
-8. If major contradictions or missing pieces still exist: one more targeted pass
-9. Otherwise: proceed to filing
+9. If major contradictions or missing pieces still exist: one more targeted pass
+10. Otherwise: proceed to filing
 
 Max rounds: 3 (as set in program.md). Stop when depth is reached or max rounds hit.
 ```
@@ -209,5 +325,20 @@ Follow the limits in `references/program.md`:
 - Max pages per session (default: 15)
 - Confidence scoring rules
 - Source preference rules
+- Quality-sites whitelist from `references/quality-sites.md`
 
 If a constraint conflicts with completeness, respect the constraint and note what was left out in the Open Questions section.
+
+---
+
+## Toolchain Summary
+
+| Purpose | Tool | Command |
+|---|---|---|
+| Search | scrapling → DuckDuckGo | `$SCRAPLING extract get "https://html.duckduckgo.com/html/?q=..." ...` |
+| Fetch (simple) | scrapling get | `$SCRAPLING extract get "$URL" "$FILE".md --ai-targeted` |
+| Fetch (JS) | scrapling fetch | `$SCRAPLING extract fetch "$URL" "$FILE".md --ai-targeted --network-idle` |
+| Fetch (anti-bot) | scrapling stealthy-fetch | `$SCRAPLING extract stealthy-fetch "$URL" "$FILE".md --ai-targeted --solve-cloudflare` |
+| Clean | defuddle | `defuddle parse "$INFILE" --md > "$OUTFILE"` |
+| Read | read tool | `read /tmp/autoresearch-*.md` |
+| File | write/edit tools | Create wiki pages |

--- a/.agents/skills/autoresearch/references/program.md
+++ b/.agents/skills/autoresearch/references/program.md
@@ -4,11 +4,137 @@ This file configures the autoresearch loop. Edit it to match your domain and res
 
 ---
 
+## Query Routing (MANDATORY)
+
+The agent has two resolvers. Never mix their domains.
+
+### context7: API & Library Documentation (EXCLUSIVE)
+
+```bash
+ctx7 library <name> <query>     # Step 1: resolve library ID
+ctx7 docs <libraryId> <query>   # Step 2: fetch docs
+```
+
+**context7 owns ALL of:**
+- Function/method signatures and parameters
+- Class APIs and inheritance
+- Configuration options, defaults, enums
+- Language standard library references
+- Framework API specifications
+- Version-specific API changes
+- Package/module documentation
+
+**Never use scrapling, defuddle, or quality-sites for the above.** API docs live in context7.
+
+### scrapling + defuddle + quality-sites: Everything Else
+
+**Use for:**
+- Debugging errors and stack traces
+- Architecture patterns and system design
+- Library/framework comparisons
+- New technology exploration
+- "How to build X" (non-API-specific)
+- Postmortems, engineering blog deep dives
+- Ecosystem trends and emerging patterns
+
+**Hybrid queries** (common):
+- Error messages: context7 for the API involved + scrapling for debugging discussions
+- Architecture decisions: context7 for involved libraries' capabilities + quality-sites for patterns
+- Library selection: context7 for each library's API surface + quality-sites for community comparisons
+
+---
+
+## Web Fetch Pipeline (MANDATORY)
+
+The agent uses a three-tier pipeline for all web fetches. Never use `curl`, `wget`, or raw bash HTTP commands.
+
+### Tier 1: Scrapling (primary fetcher)
+
+```bash
+SCRAPLING="/home/aryaniyaps/.local/venvs/scrapling/bin/scrapling"
+$SCRAPLING extract get "$URL" "$OUTFILE" --ai-targeted
+```
+
+- `--ai-targeted` extracts only main content, strips hidden elements, blocks ads
+- Output format determined by file extension: `.md` for markdown, `.html` for raw, `.txt` for plain text
+- Always prefer `.md` output for readability
+- Use `--css-selector` to target specific page regions
+- For JS-heavy or anti-bot sites, escalate to `fetch` or `stealthy-fetch`:
+  ```bash
+  $SCRAPLING extract fetch "$URL" "$OUTFILE".md --ai-targeted --network-idle
+  $SCRAPLING extract stealthy-fetch "$URL" "$OUTFILE".md --ai-targeted --solve-cloudflare
+  ```
+
+### Tier 2: Defuddle (content cleaner)
+
+After scrapling fetch, if output still has boilerplate:
+
+```bash
+defuddle parse "$OUTFILE" --md > "$CLEANFILE"
+```
+
+Or fetch-and-clean in one pass for simple pages (no anti-bot needed):
+
+```bash
+defuddle parse "$URL" --md > "$OUTFILE"
+```
+
+Defuddle is optional if scrapling `--ai-targeted` already produced clean output. Check the output: if it contains nav bars, cookie banners, or related-article sections, run defuddle.
+
+### Tier 3: Raw fallback
+
+If both scrapling and defuddle fail, use the agent's built-in WebFetch tool. Note this in the source page as low-confidence due to lack of anti-bot/cleaning.
+
+### Workflow
+
+```
+Search query → scrapling get URL → check output → defuddle if needed → read file → extract
+```
+
+Temp files go to `/tmp/autoresearch-*`. Always clean up temp files after extracting.
+
+---
+
+## Search Execution
+
+The agent has no built-in `WebSearch` tool. Search via scrapling on DuckDuckGo:
+
+```bash
+SEARCH_URL="https://html.duckduckgo.com/html/?q=$(python3 -c "import urllib.parse; print(urllib.parse.quote('''$QUERY'''))")"
+$SCRAPLING extract get "$SEARCH_URL" /tmp/autoresearch-search.md --ai-targeted
+```
+
+Parse results from the saved markdown. Extract URLs from result links. For each candidate URL, run the Tier 1→2 pipeline.
+
+If DuckDuckGo is blocked or returns empty, escalate to browser mode:
+
+```bash
+$SCRAPLING extract fetch "$SEARCH_URL" /tmp/autoresearch-search.md --ai-targeted
+```
+
+---
+
+## Quality Sites
+
+Before fetching or citing any non-API source, check `references/quality-sites.md`. The whitelist defines three tiers for debugging, architecture, and problem-solving content:
+
+- **Tier 1**: High-signal sources (StackOverflow, GitHub issues, engineering blogs, martinfowler, arxiv). Always prefer. Highest confidence.
+- **Tier 2**: Good secondary sources (Medium, dev.to, freeCodeCamp, logrocket). High confidence but verify.
+- **Tier 3**: Contextual pointers (Reddit, YouTube talks). Flag as medium confidence. Never cite directly.
+
+**API documentation sites are EXCLUDED** from quality-sites. All API docs are resolved exclusively by context7. See Query Routing above.
+
+When multiple non-API sources exist on a topic, prefer higher-tier sources.
+
+For debugging and problem-solving, use the routing patterns in `quality-sites.md` (e.g., `site:stackoverflow.com`, `site:github.com/org/repo/issues`).
+
+---
+
 ## Search Objectives
 
 Default objectives for every research session:
 
-- Find authoritative sources (prefer: .edu, peer-reviewed papers, official documentation, primary sources, established publications)
+- Find authoritative sources (prefer: Tier 1 and Tier 2 from quality-sites.md for non-API content; context7 for API/library docs; .edu; peer-reviewed papers; primary sources; established publications)
 - Extract key entities (people, organizations, products, tools)
 - Extract key concepts and frameworks
 - Note contradictions between sources
@@ -50,11 +176,17 @@ Always note the source date for factual claims. Mark claims from sources older t
 
 ## Domain Notes
 
-[Add domain-specific instructions here. Examples:]
-
 For AI/tech research:
 - Prefer: arXiv, official GitHub repos, official product documentation, Hacker News discussions with high karma
 - Note: LLM benchmarks are often gamed: treat leaderboard claims as low confidence unless independently verified
+
+For coding/API research:
+- API/library docs: use context7 exclusively (not quality-sites, not scrapling)
+- Debugging errors: context7 for the API involved + quality-sites Tier 1 (StackOverflow, GitHub issues)
+- Architecture/pattern research: quality-sites Tier 1 (martinfowler, highscalability, engineering blogs)
+- Library version/release: check pypi.org / crates.io / npmjs.com directly
+- Avoid: w3schools, geeksforgeeks, tutorialspoint, AI-generated content farms
+- Avoid: API doc mirrors (docs.rs, readthedocs.io) — use context7 instead
 
 For business/market research:
 - Prefer: company filings, Crunchbase, Bloomberg, verified industry reports
@@ -73,3 +205,4 @@ Do not cite as high-confidence sources:
 - Social media posts
 - Undated web pages
 - Sources that don't cite their own claims
+- Sites from the exclusions list in `quality-sites.md` (AI content farms, mirrors, stale packages)

--- a/.agents/skills/autoresearch/references/quality-sites.md
+++ b/.agents/skills/autoresearch/references/quality-sites.md
@@ -1,0 +1,117 @@
+# Quality Sites Whitelist
+
+Vetted sources for non-API references: debugging, architecture patterns, system design, problem-solving, and general coding knowledge. **API/library documentation is always resolved by context7, never by these sites.**
+
+## Context7 vs Quality Sites — Clear Split
+
+| Query type | Resolver | Example |
+|---|---|---|
+| API signature, method docs, library usage | **context7 only** | "What params does asyncio.gather take?" |
+| Error debugging, stack traces | quality-sites + context7 (API part) | "RuntimeError: event loop already running" |
+| Architecture patterns, system design | quality-sites | "Event-driven vs message-driven architecture" |
+| "How to build X" (non-API) | quality-sites | "How to design a rate limiter" |
+| Library comparison, ecosystem | quality-sites | "FastAPI vs Flask in 2025" |
+| New tech, emerging patterns | quality-sites | "What's new in distributed tracing" |
+| Package version, release status | pypi.org / crates.io / npmjs.com directly | "Latest sqlalchemy version" |
+
+---
+
+## Tier 1 — Primary (always prefer)
+
+High-signal sources for debugging, architecture, and real-world solutions.
+
+| Domain | Covers | Notes |
+|---|---|---|
+| `stackoverflow.com` (score ≥ 5) | Debugging, problem-solving | Prefer answers with linked primary sources. Check answer date |
+| `github.com` (issues, discussions, repo READMEs) | Bug reports, real-world solutions, architecture decisions | Prefer official org repos. Check issue resolution, stars, recent commits |
+| `news.ycombinator.com` (high-karma threads) | Architecture debates, tech trends, postmortems | Use as discovery, not authority. Follow links to primary sources |
+| `arxiv.org` (CS papers) | Algorithms, distributed systems, new architectures | Prefer papers with cited implementations or known authors |
+| `martinfowler.com` | Architecture patterns, refactoring, microservices | Canonical for enterprise patterns |
+| `highscalability.com` | System design, scaling stories | Real-world architecture case studies |
+| Official engineering blogs | Deep dives, postmortems, architecture decisions | e.g., `netflixtechblog.com`, `engineering.fb.com`, `dropbox.tech`, `slack.engineering`, `blog.cloudflare.com` |
+
+---
+
+## Tier 2 — Secondary (high confidence, verify)
+
+Good quality but not primary. Use when Tier 1 is insufficient.
+
+| Domain | Covers | Notes |
+|---|---|---|
+| `medium.com` | Tutorials, architecture posts, opinion | Check author credentials + date. Skip paywalled |
+| `dev.to` | Tutorials, discussion, how-to | Community posts, variable quality. Check author history |
+| `freecodecamp.org/news` | Tutorials, explained concepts | Generally solid, but not primary |
+| `blog.logrocket.com` | Frontend/backend tutorials | Decent quality, verify claims against primary sources |
+| `digitalocean.com/community` | DevOps, Linux, deployment tutorials | Generally reliable, well-maintained |
+| `lobste.rs` | Curated tech discussion | Higher signal than Reddit, smaller community |
+| `kracekumar.com` / personal tech blogs | Deep dives, niche topics | Check if author is known in the field |
+| `bytes.dev` / `pragmaticengineer.com` | Newsletter-style, industry trends | Good for ecosystem awareness, not primary |
+
+---
+
+## Tier 3 — Contextual (use as pointers only)
+
+Flag as medium confidence. Never cite as sole authority.
+
+| Domain | Covers | Notes |
+|---|---|---|
+| `reddit.com` (r/programming, r/rust, r/python, r/devops, etc.) | Discussion, problem-solving | Use ONLY to find primary sources. Never cite directly |
+| `youtube.com` (conference talks, official channels) | Talks, tutorials | Prefer talks from recognized conferences (PyCon, RustConf, KubeCon, etc.) |
+| `github.com/gist` | Code snippets, quick examples | No version guarantee. Read-only reference |
+| `twitter.com` / `x.com` (known experts) | Quick takes, announcements | Verify before citing. Link to the actual source, not the tweet |
+
+---
+
+## Routing Rules
+
+### When to use context7 (ALWAYS for API docs)
+
+```
+ctx7 library <name> <query>     # Step 1: resolve library ID
+ctx7 docs <libraryId> <query>   # Step 2: fetch docs
+```
+
+**Use context7 for:**
+- Function/method signatures and parameters
+- Class hierarchies and inheritance
+- Configuration options and defaults
+- Any question answered by official library documentation
+- Version-specific API changes
+
+**NEVER use scrapling/quality-sites for:**
+- Library/API documentation
+- Language standard library references
+- Framework configuration reference
+- Package API specifications
+
+### When to use quality-sites + scrapling
+
+**Use for:**
+- "Why am I getting this error?" → scrapling search + stackoverflow/github issues
+- "What architecture should I use?" → martinfowler, highscalability, engineering blogs
+- "How does X compare to Y?" → multiple Tier 1/2 sources, check dates
+- "What's new in X ecosystem?" → HN, engineering blogs, conference talks
+- "How did company Z solve problem W?" → engineering blogs, conference talks
+
+### Hybrid queries (common)
+
+Many queries span both domains. Split them:
+
+```
+Query: "asyncio.gather RuntimeError event loop already running"
+→ context7: ctx7 docs python asyncio.gather (API reference)
+→ quality-sites: scrapling search stackoverflow for the error (debugging)
+→ Synthesize both findings
+```
+
+---
+
+## Exclusions (do not cite)
+
+- **API documentation sites**: docs.python.org, MDN, doc.rust-lang.org, golang.org/pkg, nodejs.org/docs, kubernetes.io/docs, docs.docker.com, react.dev, tailwindcss.com/docs, postgresql.org/docs, docs.rs, readthedocs.io — these are context7's domain
+- **AI-generated content farms**: geeksforgeeks, w3schools (for non-web), tutorialspoint, javatpoint, programiz
+- **Content scrapers/mirrors** that duplicate official docs or StackOverflow
+- **Undated blog posts** or articles without author attribution
+- **Package registries** used as information sources (use only for version/release checking)
+- **LLM-generated tutorial sites** with no human author verification
+- **Paywalled articles** on Medium or elsewhere

--- a/.agents/skills/wiki-ingest/SKILL.md
+++ b/.agents/skills/wiki-ingest/SKILL.md
@@ -54,8 +54,11 @@ Trigger: user passes a URL starting with `https://`.
 
 Steps:
 
-1. **Fetch** the page using WebFetch.
-2. **Clean** (optional): if `defuddle` is available (`which defuddle 2>/dev/null`), run `defuddle [url]` to strip ads, nav, and clutter. Typically saves 40-60% tokens. Fall back to raw WebFetch output if not installed.
+1. **Fetch** the page using scrapling (primary) or defuddle (fallback for simple pages):
+   - Primary: `SCRAPLING=/home/aryaniyaps/.local/venvs/scrapling/bin/scrapling; $SCRAPLING extract get "$URL" /tmp/ingest.md --ai-targeted`
+   - JS/protected pages: escalate to `fetch` or `stealthy-fetch` with `--ai-targeted --network-idle`
+   - Simple fallback: `defuddle parse "$URL" --md > /tmp/ingest.md`
+2. **Clean** (optional): if scrapling output has boilerplate, run `defuddle parse /tmp/ingest.md --md > /tmp/ingest-clean.md`
 3. **Derive slug** from the URL path (last segment, lowercased, spaces→hyphens, strip query strings).
 4. **Save** to `vault/.raw/articles/[slug]-[YYYY-MM-DD].md` with a frontmatter header:
    ```markdown

--- a/.pi/SYSTEM.md
+++ b/.pi/SYSTEM.md
@@ -17,8 +17,21 @@ INSTRUCTION ORDER
 4) Local conventions from repo files.
 
 WEB POLICY (MANDATORY)
-- Use scrapling first for web lookup (non-interactive flags).
-- If scrapling missing, install via skill instructions, then continue.
+- NEVER use curl, wget, or raw bash HTTP for web fetches.
+- API/LIBRARY DOCS: context7 ONLY. ctx7 library <name> <query> then ctx7 docs <id> <query>.
+  - context7 owns: function signatures, class APIs, config options, stdlib, framework specs.
+  - NEVER use scrapling/defuddle/quality-sites for API docs.
+- NON-API WEB FETCH: scrapling CLI (venv at /home/aryaniyaps/.local/venvs/scrapling/bin/scrapling)
+  - Simple pages: scrapling extract get "$URL" out.md --ai-targeted
+  - JS pages: scrapling extract fetch "$URL" out.md --ai-targeted --network-idle
+  - Protected: scrapling extract stealthy-fetch "$URL" out.md --ai-targeted --solve-cloudflare
+- POST-CLEAN (optional): defuddle parse infile --md > cleanfile if scrapling output has boilerplate
+- SEARCH: DuckDuckGo via scrapling get (no built-in WebSearch tool)
+- QUALITY SITES: check .pi/skills/autoresearch/references/quality-sites.md before citing non-API sources
+  - Prefer Tier 1 (stackoverflow, github issues, engineering blogs, arxiv). Exclude AI content farms, mirrors, stale packages.
+- If scrapling missing: python3 -m venv ~/.local/venvs/scrapling && ~/.local/venvs/scrapling/bin/pip install "scrapling[all]>=0.4.7"
+- If defuddle missing: npm install -g defuddle-cli
+- If context7 missing: npm install -g ctx7@latest
 
 SKILL ROUTING (REFERENCE ALL INSTALLED/AVAILABLE SKILLS)
 - caveman: default communication mode.

--- a/vault/wiki/concepts/inline-post-edit-validation.md
+++ b/vault/wiki/concepts/inline-post-edit-validation.md
@@ -12,22 +12,25 @@ related:
   - "[[grounding-checkpoints]]"
   - "[[adversarial-verification]]"
   - "[[research-wozcode-token-reduction]]"
+  - "[[harness-implementation-plan]]"
 status: developing
 ---
 
 # Inline Post-Edit Validation
 
-Inline post-edit validation runs compilers, linters, and parsers immediately after each code edit — before the model sees the result. Errors are caught at the tool layer, not at the agent reasoning layer, eliminating unnecessary retry round-trips.
+Inline post-edit validation runs **compilers and parsers** immediately after each code edit — before the model sees the result. Syntax errors are caught at the tool layer, not at the agent reasoning layer, eliminating unnecessary retry round-trips. Linting and formatting are deferred to Phase 16: a single deterministic final gate that runs after L4 adversarial verification passes. See [[harness-implementation-plan#phase-16-final-lint-format-gate|Phase 16]].
 
 ## How It Differs From Our Current Approach
 
-| Aspect | Current Harness (L3+L4) | WOZCODE (Inline) |
-|--------|------------------------|-------------------|
-| **When validation runs** | After all edits, before next phase | After each individual edit |
-| **Who sees errors** | Model sees errors, reformulates | Tool layer catches errors, auto-fixes or enriches |
-| **Error context** | Raw compiler/linter output | Dialect-specific hints, location-precise diffs |
-| **Auto-fix capability** | None | SQL dialect rewrites, common pattern fixes |
-| **Token cost** | Error + re-edit = full round-trip | Caught pre-model = zero model tokens |
+| Aspect | Current Harness (L3+L4) | WOZCODE (Inline) | Our Design (Phase 12 + 16) |
+|--------|------------------------|-------------------|---------------------------|
+| **When syntax validation runs** | After all edits, before next phase | After each individual edit | After each individual edit (Phase 12) |
+| **When linting runs** | N/A (not in pipeline) | Inline after each edit | Once, post-L4 verification (Phase 16) |
+| **When formatting runs** | N/A (not in pipeline) | Inline after each edit | Once, post-L4, absolute last code-modifying step (Phase 16) |
+| **Who sees errors** | Model sees errors, reformulates | Tool layer catches errors, auto-fixes or enriches | Syntax: tool layer. Lint/format: deterministic gate, no LLM |
+| **Error context** | Raw compiler/linter output | Dialect-specific hints, location-precise diffs | Syntax: enriched diffs. Lint: structured violation report |
+| **Auto-fix capability** | None | SQL dialect rewrites, common pattern fixes | Syntax: SQL dialect. Lint: eslint --fix, biome --fix, ruff --fix. Format: always auto-applied |
+| **Token cost** | Error + re-edit = full round-trip | Caught pre-model = zero model tokens | Syntax inline: zero. Lint/format gate: zero (deterministic tools) |
 
 ## WOZCODE's Implementation (Source: [[wozcode]])
 
@@ -54,32 +57,56 @@ When an error does reach the model, WOZCODE enriches it:
 
 ## Integration Into Our Harness
 
-### Layer 3: Grounding Checkpoints
+### Phase 12: Inline Syntax Validation (L3)
 Current: `grounding-check` validates spec compliance and state integrity.
 
 Add: `post-edit-validate` hook that runs immediately after each `edit` tool invocation:
-1. Run language-appropriate linter/compiler
-2. If errors → attempt auto-fix (configurable)
+1. Run language-appropriate compiler/parser (NOT linter, NOT formatter)
+2. If errors → attempt auto-fix (SQL dialect only; type errors surfaced)
 3. If auto-fix fails → enrich error with context, return to model
 4. If success → proceed to next edit
+
+**Gate rule**: Inline validator MUST complete in <2 seconds. Full-project `tsc`, ESLint with plugins, and prettier are excluded — they belong in Phase 16.
+
+### Phase 16: Final Lint + Format Gate (post-L4)
+After L4 adversarial verification passes, a deterministic gate runs:
+1. Lint with auto-fix (ESLint, biome, ruff, clippy)
+2. Format with auto-apply (prettier, biome, rustfmt)
+3. Verify format didn't introduce lint violations
+4. Verdict: PASS / PASS_WITH_WARNINGS / FAIL
+
+See [[harness-implementation-plan#phase-16-final-lint-format-gate|Phase 16]] for full specification.
 
 ### Layer 4: Adversarial Verification
 Current: Critic agents attack after all edits are complete.
 
-This remains unchanged — inline validation handles syntax errors; adversarial verification handles semantic/logic errors. The layers are complementary:
-- **Inline (L3)**: "Does it compile/parse?" (fast, tool-level)
-- **Adversarial (L4)**: "Is it correct?" (slow, agent-level)
+This remains unchanged — inline validation handles syntax errors; adversarial verification handles semantic/logic errors; final gate handles lint/format. The layers are complementary:
+- **Inline (L3/Phase 12)**: "Does it compile/parse?" (fast, tool-level, syntax only)
+- **Adversarial (L4)**: "Is it correct?" (slow, agent-level, semantic)
+- **Final Gate (Phase 16)**: "Is it clean?" (fast, deterministic, lint + format)
 
-### Supported Validators
+### Supported Inline Validators (Phase 12 — Syntax Only)
 
 | Language/Format | Validator | Auto-Fix Scope |
 |-----------------|-----------|---------------|
-| TypeScript/JavaScript | `tsc --noEmit`, ESLint | None initially (type errors too complex) |
+| TypeScript/JavaScript | `tsc --noEmit` (single file) | None (type errors surfaced to model) |
 | JSON | `JSON.parse` | Trailing commas, unquoted keys |
-| YAML | `yaml.parse` | Indentation fixes |
-| SQL | Dialect-specific linter | Backtick→quote, reserved words |
-| Python | `py_compile`, `ruff` | Import ordering, unused imports |
+| YAML | `yaml.parse` | None (structural errors surfaced) |
+| SQL | Dialect-specific parser | Backtick→quote, reserved words |
+| Python | `py_compile` (single file) | None (syntax errors surfaced) |
 | HTML | HTML parser | Unclosed tags |
+
+### Final Gate Tooling (Phase 16 — Lint + Format)
+
+These run ONCE after L4 verification passes. Never inline.
+
+| Language | Linter (auto-fix) | Formatter |
+|----------|-------------------|-----------|
+| TypeScript/JavaScript | `eslint --fix` or `biome check --fix` | `prettier --write` or `biome format --write` |
+| Python | `ruff check --fix` | `ruff format` |
+| Rust | `clippy --fix` | `rustfmt` |
+| JSON/YAML | `prettier --write` | `prettier --write` |
+| SQL | `sqlfluff fix` | `sqlfluff format` |
 
 ## Token Savings Mechanism
 

--- a/vault/wiki/hot.md
+++ b/vault/wiki/hot.md
@@ -9,7 +9,45 @@ tags: []
 # Recent Context
 
 ## Last Updated
-2026-04-30. Consensus debate protocol designed. pi-messenger analyzed, stripped, integrated.
+2026-04-30. Lint + Format Gate split from inline validation. First-principles pipeline reorder: syntax inline, lint/format final.
+
+## Lint + Format: First-Principles Pipeline Rethink (2026-04-30)
+
+**Verdict**: Split Phase 12. Inline = syntax only (compilers/parsers). Lint + format = final gate (Phase 16, post-L4).
+
+### First Principles
+- Three distinct quality concerns: syntax (does it parse?), semantics (is it correct?), style (is it clean?)
+- Each has different timing requirements. Bundling them wastes tokens and breaks tool contracts.
+- **Syntax belongs inline** (Phase 12): broken code blocks all progress. Catch at tool layer, save round-trips.
+- **Semantics belongs in L4**: adversarial verification needs full context, spec comparison, LLM reasoning.
+- **Lint + format belongs at the end** (Phase 16, new): lint is noisy on in-progress code. Formatting modifies whitespace → breaks edit tool `oldText` exact matching. Both waste agent tokens on cosmetic decisions invalidated by next edit.
+
+### New Phase 16: Final Lint + Format Gate
+- **Position**: L3 (edits + inline syntax checks) → L4 (adversarial verification) → **Phase 16 (lint + format)** → L5 (observability)
+- **Ordering**: Lint → auto-fix lint → format → verify format didn't introduce violations → verdict
+- **Verdicts**: PASS (zero violations), PASS_WITH_WARNINGS (non-auto-fixable warnings), FAIL (errors needing manual fix, max 1 retry)
+- **Tooling**: eslint/ruff/clippy (lint + auto-fix), prettier/biome/rustfmt (format auto-apply)
+- **Token cost**: Near-zero (deterministic tooling). Time: <10s for typical projects.
+- **Files**: `lib/harness-polish.ts`, `extensions/harness-polish.ts`
+
+### Phase 12 Renamed: Inline Syntax Validation
+- **Was**: "Inline Post-Edit Validation" with compilers + linters + formatters
+- **Now**: Syntax only — `tsc --noEmit`, `JSON.parse`, `yaml.parse`, SQL parser
+- **Gate rule**: Must complete in <2s. Full-project tsc, ESLint with plugins, prettier excluded.
+- **Linting/formatting removed from inline validators table** in [[inline-post-edit-validation]]
+
+### Why Not Inline
+- Formatting modifies every line → edit tool's `oldText` won't match on next edit → guaranteed failure
+- Linting on half-written code produces noise (unused imports, missing types), not signal
+- Agent context-switches to fix style when code might be rewritten next edit
+- Human analogy: spell-checker autocorrecting while you're still drafting
+
+### Pipeline Order
+```
+L1(Spec) → L2(Plan) → L3(Edit+Syntax) → L4(Verify) → [Phase 16: Lint+Format] → L5(Observe) → L6(Memory) → L7(Orch) → L8(Query)
+```
+
+---
 
 ## Consensus Debate: Multi-Agent Argument for Harness (2026-04-30)
 
@@ -135,7 +173,8 @@ Harness L1/L2/L4 → Consensus Protocol Layer → pi-messenger Transport → Fil
 ## Active Threads
 - **Harness Phase 10**: AST truncation — leverage existing tree-sitter infra from repo-map-ranking
 - **Harness Phase 11**: Fuzzy edit matching — add normalization layer to edit tool
-- **Harness Phase 12**: Inline post-edit validation — add post-edit-validate hook to L3 grounding checkpoints
+- **Harness Phase 12**: Inline syntax validation (compilers/parsers only — NO linters, NO formatters)
+- **Harness Phase 16 (NEW)**: Final lint + format gate — runs once after L4, before L5
 - **Harness Phase 13**: Haiku model router — new ModelRouter component, woz:explore subagent
 - **Revised token budget**: ~17,500 → ~12,500-15,000 tokens per subtask (15-30% overhead reduction)
 - **Open questions**: AST truncation on dynamic languages, fuzzy matching false-positive rate, Haiku hallucination risk in summaries

--- a/vault/wiki/index.md
+++ b/vault/wiki/index.md
@@ -43,7 +43,7 @@ This wiki maps the codebase architecture and tracks key software design decision
 | [[execution-feedback-loop]] | Agent debug-test-iterate cycle via structured test output |
 | [[ast-truncation]] | Stubbing function bodies at AST level for token-efficient code reading |
 | [[fuzzy-edit-matching]] | Diff algorithm tolerating formatting drift to eliminate edit retries |
-| [[inline-post-edit-validation]] | Running compilers/linters after each edit, before model sees errors |
+| [[inline-post-edit-validation]] | Compiler/parser validation after each edit (syntax only — lint/format deferred to Phase 16) |
 | [[model-routing-agents]] | Dispatching exploration to cheap models (Haiku), code gen to frontier |
 | [[codebase-to-context-ingestion]] | Converting entire codebases into structured LLM context |
 | [[think-in-code]] | Paradigm: write code to process data, don't read raw data into context |

--- a/vault/wiki/log.md
+++ b/vault/wiki/log.md
@@ -1,5 +1,11 @@
 # Wiki Operations Log
 
+## [2026-04-30] harness | First-principles rethink: split lint+format from inline validation → new Phase 16
+- Decision: Lint + format must NEVER run inline. Syntax validation (compilers/parsers) stays inline (Phase 12). Lint + format becomes final gate (Phase 16, post-L4).
+- Pages updated: [[harness-implementation-plan]] (Phase 12 renamed, Phase 16 added, build phases table, token budget, architecture changes), [[inline-post-edit-validation]] (removed linters from inline, added Phase 16 pointer, split validator tables), [[hot]] (new entry), [[log]] (this entry)
+- Key finding: Three distinct quality concerns with different timing — syntax (inline, blocks progress), semantics (L4, needs LLM), style (final gate, deterministic tools). Bundling them wastes tokens + breaks edit tool contracts. Formatting MUST be last: it touches every line, invalidating all line numbers for any subsequent operation.
+- Pipeline order: L3(Edit+Syntax) → L4(Verify) → Phase 16(Lint+Format) → L5(Observe)
+
 ## [2026-04-30] research | Consensus Debate: Multi-Agent Argument for Harness
 - Rounds: 1 (direct first-principles analysis + pi-messenger source analysis)
 - Sources found: 1 (pi-messenger GitHub: registry, store, handlers, crew source)

--- a/vault/wiki/modules/harness-implementation-plan.md
+++ b/vault/wiki/modules/harness-implementation-plan.md
@@ -18,6 +18,7 @@ related:
   - "[[adr-011]]"
   - "[[consensus-debate]]"
   - "[[pi-messenger-analysis]]"
+  - "[[inline-post-edit-validation]]"
 ---
 
 # Harness Implementation Plan
@@ -38,6 +39,13 @@ Project page for the ultimate-pi agentic harness implementation. See the full co
 | 7 | Observability (L6) | `lib/harness-observability.ts`, `extensions/harness-observability.ts` |
 | 8 | Archon Integration (L7) | `.archon/workflows/*.yaml`, `.archon/commands/harness.md` |
 | 9 | Package integration | Update package.json, README, PLAN.md |
+| 10 | AST Truncation | `lib/harness-ast.ts`, `lib/harness-search.ts` |
+| 11 | Fuzzy Edit Matching | `lib/harness-edit.ts` |
+| 12 | Inline Syntax Validation | `lib/harness-validate.ts`, `lib/harness-sql-fix.ts` |
+| 13 | Haiku Model Router | `lib/harness-router.ts`, `lib/harness-explorer.ts` |
+| 14 | Consensus Transport | `lib/harness-messenger.ts`, `lib/harness-debate.ts` |
+| 15 | Consensus Protocol | `extensions/harness-debate.ts`, layer extension updates |
+| 16 | Final Lint + Format Gate | `lib/harness-polish.ts`, `extensions/harness-polish.ts` |
 
 ## Key Architecture Decisions
 
@@ -92,17 +100,21 @@ Add normalization layer to the `edit` tool. See [[fuzzy-edit-matching]].
 
 **Expected savings**: Eliminates 5-15% of retry round-trips.
 
-### Phase 12: Inline Post-Edit Validation
+### Phase 12: Inline Syntax Validation
 
-Run compilers/linters/parsers after each edit, before model sees result. See [[inline-post-edit-validation]].
+Run compilers and parsers after each edit, before model sees result. **Syntax only** — does the code parse/compile? Linting and formatting are deferred to [[#phase-16-final-lint-format-gate|Phase 16]] (post-verification final gate). See [[inline-post-edit-validation]].
+
+**First-principles rationale**: Syntax errors block all further progress — the model wastes tokens reasoning about code that doesn't compile. Catching at the tool layer saves full round-trips. But lint warnings (style, unused vars) and formatting (whitespace changes) must NEVER run inline: lint is noisy on in-progress code, and formatting modifies whitespace which breaks the `edit` tool's exact-match `oldText` contract.
 
 | Capability | Files | Depends On |
 |-----------|-------|------------|
 | `post-edit-validate` hook (L3) | `lib/harness-executor.ts` | Grounding checkpoints |
-| TS/JS syntax validation | `lib/harness-validate.ts` | `tsc --noEmit` |
-| JSON/YAML parser validation | `lib/harness-validate.ts` | None |
-| SQL dialect auto-fix | `lib/harness-sql-fix.ts` | SQL linter |
+| TS/JS compile check | `lib/harness-validate.ts` | `tsc --noEmit` |
+| JSON/YAML parse check | `lib/harness-validate.ts` | None |
+| SQL dialect auto-fix | `lib/harness-sql-fix.ts` | SQL parser |
 | Better error context (real diffs) | `lib/harness-executor.ts` | Post-edit validate |
+
+**Gate rule**: Inline validators MUST complete in <2 seconds. Anything slower (full project `tsc`, ESLint with plugins, prettier) belongs in Phase 16.
 
 **Expected savings**: Catches syntax errors pre-model — 10-20% reduction in error-recovery tokens.
 
@@ -129,9 +141,34 @@ Route read-only exploration to cheaper model. See [[model-routing-agents]].
 | Automated QA | ~3,500 | ~3,500 | No change (quality-critical) |
 | Critics (2 focus areas) | ~4,000 | ~4,000 | No change (adversarial) |
 | Observability | ~1,500 | ~1,500 | No change |
+| Final lint + format gate | — | ~0 | Deterministic tooling, no LLM |
 | Memory writes | ~1,500 | ~1,000 | Haiku for standard writes |
 | **Coding tokens** | variable | **-25-55%** | AST truncation + fuzzy edits |
 | **Total per subtask** | **~17,500** | **~12,500-15,000** | 15-30% overhead reduction |
+
+### Phase 16: Final Lint + Format Gate
+
+Run linters and formatters as a **single final pass** after L4 adversarial verification passes and before L5 observability. This is the last code-modifying step in the pipeline.
+
+**First-principles rationale**: Linting and formatting are separate concerns from syntax and correctness. The pipeline enforces the correct ordering: first make it work (L3 syntax + L4 verification), then make it clean (Phase 16). Running lint/format inline would: (a) flood the agent with style warnings on in-progress code, (b) break edit tool `oldText` matching via whitespace changes, (c) waste tokens on cosmetic fixes for code that might be rewritten next edit. Formatting MUST be last — it touches every line, invalidating all line numbers for any subsequent operation.
+
+| Capability | Files | Depends On |
+|-----------|-------|------------|
+| `final-polish` gate (post-L4 hook) | `lib/harness-polish.ts` | Phase 5 (L4 critics) |
+| Lint with auto-fix: ESLint, biome, ruff, clippy | `lib/harness-polish.ts` | Language detection from L3 |
+| Format with auto-apply: prettier, biome, rustfmt | `lib/harness-polish.ts` | Lint pass (lint first, format second) |
+| Lint violations report (non-auto-fixable) | `lib/harness-polish.ts` | Lint pass |
+| Gate verdict: PASS / PASS_WITH_WARNINGS / FAIL | `lib/harness-polish.ts` | Full polish run |
+| Wiki artifact: polish report | `extensions/harness-polish.ts` | L6 memory writes |
+
+**Gate semantics**:
+- `PASS`: All auto-fixes applied, zero remaining lint violations → proceed to L5
+- `PASS_WITH_WARNINGS`: Auto-fixes applied, non-auto-fixable warnings remain → logged to wiki, proceed
+- `FAIL`: Lint errors that can't be auto-fixed → return to agent for manual fix (max 1 retry, then escalate)
+
+**Ordering within gate**: Lint → auto-fix lint → format → verify format didn't introduce lint violations → verdict.
+
+**Token cost**: Near-zero (deterministic tooling, no LLM involvement). Time cost: <10 seconds for typical projects.
 
 ### Fundamental Architecture Changes Required
 
@@ -139,13 +176,25 @@ These are not incremental — they require structural changes to the agent:
 
 1. **Model router layer**: The agent must dispatch operations to different models. This is a new cross-cutting concern between L7 (orchestration) and L3/L8 (execution). Currently, the harness assumes one model for all operations.
 
-2. **Inline validation pipeline**: Current validation is post-hoc (L3 checks after all edits, L4 attacks after phase complete). WOZCODE's inline validation interposes after each individual tool invocation — a fundamentally tighter loop.
+2. **Two-tier validation pipeline**: Current validation is post-hoc (L3 checks after all edits, L4 attacks after phase complete). The new design adds inline syntax validation (Phase 12, fast, tool-layer, catches broken code before model sees it) and a final lint+format gate (Phase 16, post-L4, deterministic, no LLM involvement). These are complementary — inline catches "doesn't compile", final gate catches "isn't clean". Neither replaces L4's adversarial semantic verification.
 
 3. **AST-aware tool primitives**: The `read`, `search`, and `grep` tools must become AST-aware. This requires tree-sitter integration at the tool layer, not just the planning layer (where repo-map-ranking currently sits).
 
-4. **Non-exact tool matching**: The `edit` tool's contract changes from "exact string match" to "best-effort fuzzy match with exact fallback." This is a semantic change to a core tool primitive.
+4. **Non-exact tool matching**: The `edit` tool's contract changes from "exact string match" to "best-effort fuzzy match with exact fallback." This is a semantic change to a core tool primitive. Note: fuzzy matching is tolerant of minor whitespace drift, but full formatting runs ONLY in Phase 16 — never inline.
 
 5. **Tool result intermediation**: Currently, tool results go straight to the model. With inline validation, the tool pipeline must intercept results, run validators, attempt auto-fixes, and only then surface the (possibly transformed) result to the model.
+
+---
+
+## Final Polish Gate (Phase 16)
+
+See [[#phase-16-final-lint-format-gate|Phase 16 above]] for full specification. Runs once after L4 adversarial verification passes. Lint → auto-fix → format → verify → verdict.
+
+**Pipeline position**: L3 (edits with inline syntax checks) → L4 (adversarial verification) → **Phase 16 (lint + format gate)** → L5 (observability).
+
+**Why not inline**: Formatting modifies every line — breaks `edit` tool `oldText` matching. Linting on in-progress code produces noise, not signal. Both waste agent tokens on cosmetic decisions that may be invalidated by the next edit.
+
+**Why not in L4**: L4 critics reason about correctness (logic, security, spec compliance). Lint/formatters are deterministic tools — no LLM reasoning needed. Adding them to L4 would bloat the adversarial budget with non-adversarial work.
 
 ---
 


### PR DESCRIPTION
…ormat Phase 16 split

- Web fetch: scrapling as primary fetcher (venv), defuddle parse --md for post-clean, DuckDuckGo search via scrapling
- Query routing: context7 owns ALL API/library docs, quality-sites for debugging/architecture/patterns
- Quality sites whitelist: 3 tiers (stackoverflow, github issues, engineering blogs, arxiv, martinfowler, etc.)
- Exclusions: API doc sites (docs.python.org, MDN, etc.) from quality-sites — context7 domain only
- Updated: SYSTEM.md WEB POLICY, autoresearch SKILL.md, program.md, wiki-ingest SKILL.md
- Added: references/quality-sites.md with routing rules and exclusions
- Harness: Phase 12 renamed to Inline Syntax Validation (compilers/parsers only, no linters)
- Harness: New Phase 16 Final Lint+Format Gate (post-L4, deterministic, near-zero token cost)
- Update: inline-post-edit-validation, harness-implementation-plan, hot, log, index