### PR TITLE
docs(harness): add GitHub Issues spec storage research with fork safety

### DIFF
--- a/.agents/skills/posthog-analyst/evals/evals.json
+++ b/.agents/skills/posthog-analyst/evals/evals.json
@@ -1,23 +1,23 @@
 {
-  "skill_name": "posthog-analyst",
-  "evals": [
-    {
-      "id": 1,
-      "prompt": "run a quick posthog analysis on the last 3 days — just error rates per model, nothing deep. I want to know if claude or gpt is having more problems.",
-      "expected_output": "A summary table showing error rates per model from the last 3 days, with a brief verdict on which model has more issues. Follows Quick Mode format: table with error counts and rates, offer to go deeper.",
-      "files": []
-    },
-    {
-      "id": 2,
-      "prompt": "/posthog-analyze for the last 14 days. I'm seeing tool loops where the agent keeps retrying the same failing bash command and it's wasting tokens. Check if this is model-specific and what we should change in the harness to stop it.",
-      "expected_output": "Full analysis: query results showing tool error patterns by model, identification of tool loop pattern, cross-reference with execution-feedback-loop wiki page, model-specific recommendations for gate design changes (L2). Filed to wiki as an analysis page.",
-      "files": []
-    },
-    {
-      "id": 3,
-      "prompt": "do a full postmortem on everything from yesterday. I want to know every misalignment, every error, and what specific changes each model profile needs. File it all to the wiki.",
-      "expected_output": "Comprehensive analysis filed to vault/wiki/analyses/posthog-YESTERDAY.md with per-model breakdown, pattern detection across all 5 patterns, cross-references to wiki model-adaptive-harness pages, and a prioritized recommendations table. Updates index.md, log.md, and hot.md.",
-      "files": []
-    }
-  ]
+	"skill_name": "posthog-analyst",
+	"evals": [
+		{
+			"id": 1,
+			"prompt": "run a quick posthog analysis on the last 3 days — just error rates per model, nothing deep. I want to know if claude or gpt is having more problems.",
+			"expected_output": "A summary table showing error rates per model from the last 3 days, with a brief verdict on which model has more issues. Follows Quick Mode format: table with error counts and rates, offer to go deeper.",
+			"files": []
+		},
+		{
+			"id": 2,
+			"prompt": "/posthog-analyze for the last 14 days. I'm seeing tool loops where the agent keeps retrying the same failing bash command and it's wasting tokens. Check if this is model-specific and what we should change in the harness to stop it.",
+			"expected_output": "Full analysis: query results showing tool error patterns by model, identification of tool loop pattern, cross-reference with execution-feedback-loop wiki page, model-specific recommendations for gate design changes (L2). Filed to wiki as an analysis page.",
+			"files": []
+		},
+		{
+			"id": 3,
+			"prompt": "do a full postmortem on everything from yesterday. I want to know every misalignment, every error, and what specific changes each model profile needs. File it all to the wiki.",
+			"expected_output": "Comprehensive analysis filed to vault/wiki/analyses/posthog-YESTERDAY.md with per-model breakdown, pattern detection across all 5 patterns, cross-references to wiki model-adaptive-harness pages, and a prioritized recommendations table. Updates index.md, log.md, and hot.md.",
+			"files": []
+		}
+	]
 }

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -18,27 +18,10 @@
       "sourceType": "github",
       "computedHash": "a818cdc41dcfaa50dd891c5cb5e5705968338de02e7e37949ca56e8c30ad4176"
     },
-    "compress": {
-      "source": "juliusbrussee/caveman",
-      "sourceType": "github",
-      "computedHash": "05c97bc3120108acd0b80bdef7fb4fa7c224ba83c8d384ccbc97f92e8a065918"
-    },
     "context7-cli": {
       "source": "upstash/context7",
       "sourceType": "github",
       "computedHash": "525bfb31161c3f8866920a28fb2d9a3003a23b449aa8619b1b1add0da2cc3300"
-    },
-    "cross-linker": {
-      "source": "Ar9av/obsidian-wiki",
-      "sourceType": "github",
-      "skillPath": ".skills/cross-linker/SKILL.md",
-      "computedHash": "7a90672793c6f4e5503de563ae10c59a968e61909448de195ce7ec08b47b2d62"
-    },
-    "data-ingest": {
-      "source": "Ar9av/obsidian-wiki",
-      "sourceType": "github",
-      "skillPath": ".skills/data-ingest/SKILL.md",
-      "computedHash": "233e21583eb1743fe68eb218da0a961e28af256ea4370e264370de8d2f7dffab"
     },
     "defuddle": {
       "source": "AgriciDaniel/claude-obsidian",
@@ -46,39 +29,10 @@
       "skillPath": "skills/defuddle/SKILL.md",
       "computedHash": "36d05ef63d91c999d906f1ac2ece68ad3d776b830b88352b5d36473a13b0ecbb"
     },
-    "emil-design-eng": {
-      "source": "emilkowalski/skill",
-      "sourceType": "github",
-      "computedHash": "8bdf9e4e6de7a4969147bf4828a4ad2c5aacd9fba4b690b250a85e0467ca387d"
-    },
-    "graph-colorize": {
-      "source": "Ar9av/obsidian-wiki",
-      "sourceType": "github",
-      "skillPath": ".skills/graph-colorize/SKILL.md",
-      "computedHash": "ac78796031062b02150dd1244a21b7b66b6aabf7a20f7701e99d852a53373e3c"
-    },
-    "ingest-url": {
-      "source": "Ar9av/obsidian-wiki",
-      "sourceType": "github",
-      "skillPath": ".skills/ingest-url/SKILL.md",
-      "computedHash": "16c1e8c851c89a232c0dd36e4dab35f8ab4e0f55c1af880cdd8515df0095a98e"
-    },
-    "json-canvas": {
-      "source": "kepano/obsidian-skills",
-      "sourceType": "github",
-      "skillPath": "skills/json-canvas/SKILL.md",
-      "computedHash": "56cbac74a93e4fba97f4d44bccfdeaae89e545b223f47df392c7705e01e6c543"
-    },
     "lean-ctx": {
       "source": "yvgude/lean-ctx",
       "sourceType": "github",
       "computedHash": "3d29c02c1c3928c838228cf11635c8041e52acc2e804ba2dd19450530a34c53e"
-    },
-    "llm-wiki": {
-      "source": "Ar9av/obsidian-wiki",
-      "sourceType": "github",
-      "skillPath": ".skills/llm-wiki/SKILL.md",
-      "computedHash": "5a55db4e73ca833366768ec24636bebfa5a66815cd96dbbe26d7cec4a1e39f1c"
     },
     "obsidian-bases": {
       "source": "AgriciDaniel/claude-obsidian",
@@ -109,41 +63,11 @@
       "sourceType": "github",
       "computedHash": "af9bee8b531aa5b4d499eeebca66edb0224b1ed9b61540588765140628bd7ff2"
     },
-    "skill-creator": {
-      "source": "Ar9av/obsidian-wiki",
-      "sourceType": "github",
-      "skillPath": ".skills/skill-creator/SKILL.md",
-      "computedHash": "b122f4d1e91aa1d83027e050b5b37c3156203ee85458d7b1360bc48167c9e02a"
-    },
-    "tag-taxonomy": {
-      "source": "Ar9av/obsidian-wiki",
-      "sourceType": "github",
-      "skillPath": ".skills/tag-taxonomy/SKILL.md",
-      "computedHash": "4b69929a738903c28e95985b4acfa101a65155d8cefdbef324778b4ee185c415"
-    },
     "wiki": {
       "source": "AgriciDaniel/claude-obsidian",
       "sourceType": "github",
       "skillPath": "skills/wiki/SKILL.md",
       "computedHash": "cd198f5cc31bba932b667d22d7dbd17eec46bddba70b51540701b19afd440a39"
-    },
-    "wiki-capture": {
-      "source": "Ar9av/obsidian-wiki",
-      "sourceType": "github",
-      "skillPath": ".skills/wiki-capture/SKILL.md",
-      "computedHash": "a2d82588a84ad60969aa36901a9ed1ec2f29545c0cf26223e7114563a886d10f"
-    },
-    "wiki-dashboard": {
-      "source": "Ar9av/obsidian-wiki",
-      "sourceType": "github",
-      "skillPath": ".skills/wiki-dashboard/SKILL.md",
-      "computedHash": "8205ce95d5bb660aeeb6eb4e5f5af146cdd95c7d98df70172b79ee4f385544a9"
-    },
-    "wiki-export": {
-      "source": "Ar9av/obsidian-wiki",
-      "sourceType": "github",
-      "skillPath": ".skills/wiki-export/SKILL.md",
-      "computedHash": "4b26018ff2ba71290c52e42ade0bcd8fe9bc08ea2ffa8a15bbf2200bcdf0e1f1"
     },
     "wiki-fold": {
       "source": "AgriciDaniel/claude-obsidian",
@@ -168,42 +92,6 @@
       "sourceType": "github",
       "skillPath": "skills/wiki-query/SKILL.md",
       "computedHash": "b40ba05903fba0dcee18c065d8819e6d0cb4a4f2ae3e4335404d42c833cfce82"
-    },
-    "wiki-rebuild": {
-      "source": "Ar9av/obsidian-wiki",
-      "sourceType": "github",
-      "skillPath": ".skills/wiki-rebuild/SKILL.md",
-      "computedHash": "05509c18c539777a483a7ae698954f0bdc609859449f59882b77474676a89a3e"
-    },
-    "wiki-research": {
-      "source": "Ar9av/obsidian-wiki",
-      "sourceType": "github",
-      "skillPath": ".skills/wiki-research/SKILL.md",
-      "computedHash": "a5b342f6bb06250d49126d4ec19c36adffaf143d491f40db30455d9ac9d6142c"
-    },
-    "wiki-setup": {
-      "source": "Ar9av/obsidian-wiki",
-      "sourceType": "github",
-      "skillPath": ".skills/wiki-setup/SKILL.md",
-      "computedHash": "c2076d2be2b2d7e67852c13520dbeb35e0b7ccefc677efea2d74e9cebe1678b5"
-    },
-    "wiki-status": {
-      "source": "Ar9av/obsidian-wiki",
-      "sourceType": "github",
-      "skillPath": ".skills/wiki-status/SKILL.md",
-      "computedHash": "fbcad5a1492dcc2071d5029a97ec0ce3ddbf6aebcf4db351ae5239ac53ae31e5"
-    },
-    "wiki-synthesize": {
-      "source": "Ar9av/obsidian-wiki",
-      "sourceType": "github",
-      "skillPath": ".skills/wiki-synthesize/SKILL.md",
-      "computedHash": "55c6becd6be1b5b37fb8e21e2aa04c78ff82ec0d3318e92daa7dc0df1b1f926a"
-    },
-    "wiki-update": {
-      "source": "Ar9av/obsidian-wiki",
-      "sourceType": "github",
-      "skillPath": ".skills/wiki-update/SKILL.md",
-      "computedHash": "682f61c1a3ebf1758ba457d5e51d1f620d7ae962c0a3ae183cb48849c1fa905e"
     }
   }
 }

--- a/vault/wiki/concepts/content-addressed-spec-identity.md
+++ b/vault/wiki/concepts/content-addressed-spec-identity.md
@@ -1,0 +1,167 @@
+---
+type: concept
+title: "Content-Addressed Spec Identity"
+status: developing
+created: 2026-04-30
+updated: 2026-04-30
+tags:
+  - harness
+  - spec-storage
+  - content-addressing
+  - fingerprinting
+  - fork-safety
+  - reconciliation
+related:
+  - "[[Research: GitHub Issues as Harness Spec Storage]]"
+  - "[[fork-safe-spec-storage]]"
+  - "[[spec-hardening]]"
+sources:
+  - "[[Research: GitHub Issues as Harness Spec Storage]]"
+---
+
+# Content-Addressed Spec Identity
+
+How ultimate-pi harnesses resolve specs by content fingerprint, not issue number. Solves the fork-merge divergence problem: fork's issue #5 and upstream's issue #5 are different specs found by different hashes.
+
+## The Problem
+
+GitHub Issues are identified by repo-scoped integers. When specs live in issues:
+
+| Scenario | Fork Issue | Upstream Issue | Conflict? |
+|----------|-----------|----------------|-----------|
+| Normal | `forker/proj#1` = "Add OAuth" | `owner/proj#1` = "Initial setup" | No — different repos |
+| After fork merge | `forker/proj#1` = "Add OAuth" transferred to upstream | `owner/proj#2` = "Fix rate limiter" | No — transfer assigns new number |
+| Stale cache | Local cache still says `forker/proj#1` | Issue doesn't exist in fork anymore, wrong number in upstream | **YES** — harness looks up wrong repo/number |
+
+Issue numbers are repo-scoped, time-ordered identifiers. They are NOT stable identities across repo boundaries.
+
+## The Solution: Content-Hash Identity
+
+Every HardenedSpec carries a deterministic content fingerprint that survives repo migration.
+
+### Fingerprint Generation
+
+```
+spec_fingerprint = SHA256(
+  normalize(intent_summary) +
+  normalize(json.dumps(success_criteria, sort_keys=True)) +
+  normalize(definition_of_done)
+)
+```
+
+`normalize()` strips whitespace, lowercases, removes punctuation. This makes the fingerprint tolerant of formatting changes while sensitive to semantic changes.
+
+### Embedding Points
+
+| Location | Format | Purpose |
+|----------|--------|---------|
+| Issue body (HTML comment) | `<!-- spec-fp: a1b2c3d4e5f6... -->` | Primary: searchable across repos |
+| Issue title prefix | `[spec:a1b2c3d4] Implement OAuth2 login` | Visible: human-readable first-8 prefix |
+| Local cache JSON | `"spec_fingerprint": "a1b2c3d4e5f6..."` | Fast: no API call needed for lookup |
+| Wiki page (ADR, spec page) | `spec_fingerprint: a1b2c3d4e5f6` | Cross-reference: wiki-to-issue linkage |
+
+### Resolution Algorithm
+
+When the harness needs spec `X`:
+
+```
+1. Check local cache: .pi/harness/specs/<id>.json — read spec_fingerprint
+2. Check cached issue URL: if github_issue_url exists and is reachable → use it
+3. If cached URL is stale (404, wrong repo, wrong content):
+   a. Search by fingerprint: gh search issues "spec-fp:a1b2c3d4" --label harness-spec
+   b. If found in current repo: update cache, use it
+   c. If found in different repo: warn, offer to transfer
+   d. If not found anywhere: spec is orphaned — recreate from local cache body
+4. Always verify: read issue body, extract fingerprint, compare with expected
+```
+
+### Why This Works
+
+- **Content-addressed, not location-addressed**: Like Git's object model. The spec's identity is its content, not where it lives.
+- **Repo-agnostic**: The same spec hash resolves to the correct issue in any repo.
+- **Transfer-safe**: When an issue is transferred via `gh issue transfer`, only its number changes. The body (and fingerprint within it) stays the same.
+- **Deduplication**: Two issues with the same fingerprint ARE the same spec. Harness can detect and merge duplicates.
+- **Searchable**: `gh search issues "spec-fp:abc123"` works across all repos the user has access to.
+
+## The Transfer-on-Merge Pattern
+
+When code merges from fork to upstream, specs can follow via GitHub's native issue transfer API.
+
+### `ultimate-pi harness migrate` Command
+
+```
+ultimate-pi harness migrate [--dry-run]
+  ├─ Detect repo change: current repo ≠ .pi/harness/config.json cached repo
+  ├─ List fork specs: gh issue list --repo <old-repo> --label harness-spec --json number,title,body
+  ├─ For each spec:
+  │   ├─ Search upstream: gh search issues "spec-fp:<hash>" --repo <new-repo>
+  │   ├─ If found in upstream → skip (already migrated)
+  │   ├─ If not found:
+  │   │   ├─ Transfer: gh issue transfer <issue> <new-repo>
+  │   │   ├─ Relabel: gh issue edit <new-number> --add-label harness-spec,layer-N,status:*
+  │   │   └─ Note: labels don't survive transfer — must reapply
+  │   └─ Update local cache: rewrite github_issue_url → new repo
+  ├─ Update config: .pi/harness/config.json → new repo
+  └─ Report: N transferred, M already-present, K orphaned
+```
+
+### Transfer API Constraints
+
+| Constraint | Impact |
+|------------|--------|
+| Requires write access to BOTH repos | Fork must have push access to upstream (true after PR merged) |
+| Labels are NOT transferred | Harness must reapply labels post-transfer |
+| Assignees, milestones ARE transferred | Good |
+| Comments ARE transferred | Execution audit trail preserved |
+| Sub-issues are NOT transferred | Must transfer children individually or recreate hierarchy |
+| Issue number changes | Upstream assigns next available number |
+
+### Idempotency Guarantee
+
+`harness migrate` is idempotent because it searches by fingerprint before transferring. If a spec already exists in upstream (from a previous migration run), it's skipped. Running migrate twice produces the same result.
+
+## Edge Cases
+
+### Orphaned Specs (No Fingerprint Match)
+
+If a spec exists in the fork but no matching fingerprint is found anywhere:
+- **Cause**: Issue body was edited and fingerprint comment removed, or spec was deleted
+- **Resolution**: Harness recreates the spec in upstream from the local cache JSON body
+- **Warning**: Comment history is lost (original was in fork issue, now inaccessible)
+
+### Duplicate Specs (Same Fingerprint, Different Issues)
+
+If two issues in the same repo have the same fingerprint:
+- **Detection**: `gh search issues "spec-fp:<hash>" --repo <repo>` returns multiple results
+- **Resolution**: Harness keeps the newer one (most recently updated), closes the older as duplicate with comment "Merged into #<newer> — same spec fingerprint"
+- **Rationale**: The newer issue likely has richer comment history
+
+### Cross-Fork Specs (Multiple Forks, Same Spec)
+
+If Forker-A and Forker-B both create "Add OAuth2" with different approaches:
+- **Their fingerprints WILL differ** — the `success_criteria` and `definition_of_done` are different
+- **No false collision**: fingerprint includes the full spec semantics, not just the title
+- **Correct behavior**: they remain separate specs in separate forks, as they should
+
+## Implementation Complexity
+
+| Component | Effort | Risk |
+|-----------|--------|------|
+| Fingerprint generation in SpecHardener | Low — add SHA256 call before saving | None |
+| Fingerprint embedding in issue body | Low — prepend HTML comment | None |
+| `gh search issues` integration | Low — single CLI call | None |
+| `harness migrate` command | Medium — transfer + relabel + cache update loop | Medium — transfer API edge cases |
+| Cache staleness detection | Low — compare cached URL to current repo | None |
+| Orphan recreation | Low — `gh issue create` from cached body | Low |
+| Duplicate detection | Low — count search results | None |
+
+Total: ~2-3 days of implementation. All operations use existing `gh` CLI commands or REST API.
+
+## Prior Art
+
+- **Git's content-addressed object model**: SHA1 hashes identify objects by content, not by location. This is the same principle applied to specs.
+- **IPFS / libp2p**: Content-addressed distributed storage. Specs are "CID-addressable" in concept.
+- **Nix / Guix**: Package builds are identified by content hashes of their inputs. Same deterministic identity pattern.
+- **Docker image digests**: `image@sha256:abc...` identifies an image by its content manifest, not by its tag. Tags move; digests don't.
+
+None of these are "harness spec storage" prior art — this is a novel application of content addressing to agent task management.

--- a/vault/wiki/concepts/fork-safe-spec-storage.md
+++ b/vault/wiki/concepts/fork-safe-spec-storage.md
@@ -1,0 +1,90 @@
+---
+type: concept
+title: "Fork-Safe Spec Storage"
+status: developing
+created: 2026-04-30
+updated: 2026-04-30
+tags:
+  - harness
+  - spec-storage
+  - github-issues
+  - fork
+  - multi-tenant
+  - isolation
+related:
+  - "[[Research: GitHub Issues as Harness Spec Storage]]"
+  - "[[content-addressed-spec-identity]]"
+  - "[[spec-hardening]]"
+  - "[[harness-implementation-plan]]"
+sources:
+  - "[[github-fork-issues-discussion]]"
+  - "[[Research: GitHub Issues as Harness Spec Storage]]"
+---
+
+# Fork-Safe Spec Storage
+
+How ultimate-pi's harness keeps spec storage isolated across forks. When someone forks a project using ultimate-pi, zero upstream spec state leaks into the fork.
+
+## The Problem
+
+| Threat | Mechanism |
+|--------|-----------|
+| Stale local cache | `.pi/harness/specs/<id>.json` committed to git → forked with upstream issue URLs |
+| Empty issue tracker | Fork's Issues tab is disabled by default (historical) or starts empty (post-Dec 2025) |
+| Wrong repo context | `gh` CLI authenticated to upstream, not fork |
+| Divergent issue numbers | Fork issue #5 ≠ upstream issue #5. Merge = collision |
+
+## The Solution: Three-Layer Isolation
+
+### Layer 1: Gitignored Runtime Cache
+
+`.pi/harness/specs/` is in `.gitignore`. The cache is, by definition, runtime-only. It's never committed, never pushed, never forked. Each clone starts fresh.
+
+**Rationale**: The local JSON is a **speed cache**, not a source of truth. GitHub Issues are the durable store. Caches should never be version-controlled.
+
+### Layer 2: `harness init` Bootstrap
+
+On first run in any repo (fork or not), `ultimate-pi harness init`:
+
+```
+ultimate-pi harness init
+  ├─ Detect fork: gh repo view --json isFork
+  ├─ Enable Issues: if disabled, guide user or auto-enable via API
+  ├─ gh auth check: prompt login if missing
+  ├─ gh repo set-default: point to current repo (fork, not upstream)
+  ├─ Create labels: gh label create harness-spec, harness-task, layer-1..8, status:*
+  ├─ Create templates: .github/ISSUE_TEMPLATE/harness-spec.yml
+  ├─ Gitignore: ensure .pi/harness/specs/ is in .gitignore
+  └─ Done. Idempotent — re-running is a no-op.
+```
+
+### Layer 3: GitHub's Native Repo Scoping
+
+GitHub Issues are scoped to a repository. A fork is a separate repository. Upstream's issues are never copied to forks. Each fork creates its own issues in its own namespace.
+
+| Scope | Upstream (`owner/project`) | Fork (`forker/project`) |
+|-------|---------------------------|------------------------|
+| Issue #1 | "Initial spec: auth system" | (empty — fork starts fresh) |
+| Issue #2 | "Bug: memory leak" | (empty) |
+| After `harness init` | Unchanged | Issue #1: "Spec: forker's first feature" |
+
+## Why Labels Instead of Issue Numbers
+
+Labels are the only shared artifact between upstream and fork. This is by design:
+
+- **Labels are convention, not data**. `harness-spec`, `layer-3`, `status:active` are semantic tags that mean the same thing in any repo.
+- **Labels are cheap to recreate**. `harness init` creates them in 8 API calls.
+- **Labels don't collide**. Issue #5 in upstream with `harness-spec` and issue #5 in fork with `harness-spec` are different issues with the same semantic category. No conflict.
+
+## The Merge Problem — SOLVED
+
+Fork issue #5 and upstream issue #5 are different specs. When code merges, spec identities must be reconciled. **Solution**: Content-addressed spec identity via `SHA256` fingerprinting + `gh issue transfer` API. See [[content-addressed-spec-identity]] for the full creative architecture.
+
+Summary: every spec carries a content hash in its issue body (`<!-- spec-fp: <hash> -->`). Harness resolves by hash search across repos, not by brittle issue numbers. `ultimate-pi harness migrate` transfers specs from fork to upstream on merge. Idempotent, ~2-3 days to implement.
+
+## Enforcement
+
+- L7 Schema Orchestration enforces that every harness run checks `gh repo view` before creating issues
+- `harness init` is a prerequisite gate — harness refuses to create issues until init completes
+- Config file `.pi/harness/config.json` stores the canonical repo for issue operations
+- Runtime validation: if `gh repo view --json nameWithOwner` doesn't match config, harness warns and offers re-init

--- a/vault/wiki/hot.md
+++ b/vault/wiki/hot.md
@@ -69,3 +69,19 @@ L1: Spec → L2: Plan → L2.5: Drift Monitor → L3: Execute (+TiC, +AST, +Fuzz
 ```
 
 Formal models: H=(E,T,C,S,L,V) + Feedforward-Feedback + Generator-Evaluator. All mapped to our pipeline in [[harness-control-frameworks]].
+
+### GitHub Issues as Harness Spec Storage (2026-04-30)
+
+Research: [[Research: GitHub Issues as Harness Spec Storage]] — GitHub Issues can serve as cloud-persistent spec storage with native sub-issues (parent-child hierarchies, April 2025) and issue dependencies (blocked-by/blocking).
+
+Key architecture: Dual-tier — local `.pi/harness/specs/<id>.json` for speed + GitHub Issue for cross-session ledger. Not every micro-step creates an issue; only major state transitions (spec creation, plan creation, phase completion).
+
+Toolchain: `gh issue create/edit/comment/list/view` for CRUD, `gh-sub-issue` extension (yahsan2, 110 stars, MIT) for parent-child management until `gh` CLI gains native support (cli/cli#10298). GitHub Projects v2 for optional kanban/roadmap visualization.
+
+Labels encode machine-readable state: `harness-spec`, `layer-{n}`, `status:{status}`. Issue comments serve as immutable execution audit trail.
+
+**Fork safety**: `.pi/harness/specs/` is gitignored — never committed, never forked. `ultimate-pi harness init` bootstraps a fork's own issue tracker (enable issues, create labels, set `gh` repo context). Zero upstream spec leakage into forks.
+
+Init flow: detect fork → enable issues → create labels → set repo → gitignore cache → ready. Idempotent re-runs are no-ops.
+
+**Content-addressed spec identity**: Every HardenedSpec carries a `SHA256(intent + criteria + done)` fingerprint embedded in the issue body (`<!-- spec-fp: <hash> -->`). Harness resolves specs by hash search across repos, not by brittle issue numbers. When fork merges upstream: `ultimate-pi harness migrate` transfers specs via `gh issue transfer` + relays labels. Idempotent. ~2-3 days to implement.

--- a/vault/wiki/index.md
+++ b/vault/wiki/index.md
@@ -61,6 +61,8 @@ This wiki maps the codebase architecture, tracks key software design decisions, 
 | [[guardian-agent-pattern]] | Pre-execution and post-execution safety validation |
 | [[context-anxiety]] | Models rush to finish as context window fills |
 | [[verification-drift-detection]] | Stub — see [[grounding-checkpoints]] |
+| [[fork-safe-spec-storage]] | Fork isolation: gitignored cache + `harness init` bootstrap |
+| [[content-addressed-spec-identity]] | Content-hash spec identity + `harness migrate` transfer-on-merge |
 
 ## Concepts — Context & Search
 
@@ -127,6 +129,7 @@ This wiki maps the codebase architecture, tracks key software design decisions, 
 | [[research-gitingest-gitreverse-integration]] | Gitingest adopted, GitReverse skipped |
 | [[Research: Meta-Agent Context Drift Detection]] | Novel synthesis: detect → prune → restart |
 | [[research-agentic-coding-harness-latest-papers]] | 5 pipeline improvements, 3 future phases, formal H-model |
+| [[Research: GitHub Issues as Harness Spec Storage]] | GitHub Issues as cloud-persistent spec storage with sub-issues + dependencies |
 
 ## Sources (External Research)
 
@@ -151,6 +154,11 @@ This wiki maps the codebase architecture, tracks key software design decisions, 
 | [[think-in-code-blog]] | blog | "Think in Code" by B. Mert Köseoğlu |
 | [[gitingest]] | tool | Codebase-to-structured-text for LLM context |
 | [[gitreverse]] | tool | Repo-to-synthetic-prompt (not adopted) |
+| [[github-sub-issues-docs]] | documentation | GitHub official docs on sub-issues (parent-child hierarchies) |
+| [[github-issue-dependencies-docs]] | documentation | GitHub official docs on issue dependencies (blocked-by/blocking) |
+| [[gh-sub-issue-extension]] | github-repo | Community gh CLI extension for sub-issue management |
+| [[gh-cli-sub-issue-rfc]] | github-issue | Official gh CLI feature request for native sub-issue support |
+| [[github-fork-issues-discussion]] | github-discussion | Fork issues enablement evolution (Jun-Dec 2025) |
 | [[aider-repomap-tree-sitter]] | blog | Tree-sitter + graph ranking for LLM code context |
 | [[swe-agent-aci]] | paper | Agent-Computer Interfaces concept (2024) |
 | [[swe-bench]] | paper | Real-world software engineering benchmark |

--- a/vault/wiki/log.md
+++ b/vault/wiki/log.md
@@ -1,5 +1,15 @@
 # Wiki Operations Log
 
+## [2026-04-30] autoresearch | GitHub Issues as Harness Spec Storage
+- Rounds: 1 (+ fork/multi-tenant deep dive)
+- Sources found: 5 (GH docs: sub-issues, dependencies; community: gh-sub-issue extension; feature request: cli/cli#10298; fork discussion: #161368)
+- Pages created: [[Research: GitHub Issues as Harness Spec Storage]], [[github-sub-issues-docs]], [[github-issue-dependencies-docs]], [[gh-sub-issue-extension]], [[gh-cli-sub-issue-rfc]], [[github-fork-issues-discussion]]
+- Pages created (concepts): [[fork-safe-spec-storage]], [[content-addressed-spec-identity]]
+- Pages updated: [[index]], [[log]], [[hot]]
+- Key finding: GitHub Issues has native sub-issues (April 2025, up to 8 levels deep) and issue dependencies (blocked-by/blocking) — both map directly to harness spec decomposition (L1) and task DAGs (L2). `gh` CLI lacks native support but `gh-sub-issue` extension bridges the gap. Recommended architecture: dual-tier (local JSON cache + GitHub Issue ledger) — cloud persistence for major state transitions only, not every micro-step.
+- Integration: L1 spec hardening → create parent issue. L2 structured planning → create sub-issues for tasks, link with dependencies. Issue comments as immutable execution audit log. Labels encode machine-readable state.
+- Fork safety: `.pi/harness/specs/` gitignored (runtime cache, never committed). Forks get clean issue tracker via `ultimate-pi harness init` bootstrap (enable issues, create labels, set repo context). No upstream spec leakage.
+
 ## [2026-04-30] consolidate | First-Principles Harness Consolidation
 - All April 2026 research integrated into master plan
 - Pages created: [[harness-control-frameworks]] (unified H-formalism + feedforward-feedback + generator-evaluator), [[drift-detection-unified]] (3 complementary drift paradigms with clear boundaries), [[think-in-code-enforcement]] (L3 module with 3-layer enforcement)

--- a/vault/wiki/questions/Research: GitHub Issues as Harness Spec Storage.md
+++ b/vault/wiki/questions/Research: GitHub Issues as Harness Spec Storage.md
@@ -1,0 +1,189 @@
+---
+type: synthesis
+title: "Research: GitHub Issues as Harness Spec Storage"
+created: 2026-04-30
+updated: 2026-04-30
+tags:
+  - research
+  - harness
+  - github-issues
+  - spec-storage
+  - cli
+  - persistence
+status: developing
+related:
+  - "[[harness-implementation-plan]]"
+  - "[[spec-hardening]]"
+  - "[[structured-planning]]"
+sources:
+  - "[[github-sub-issues-docs]]"
+  - "[[github-issue-dependencies-docs]]"
+  - "[[gh-sub-issue-extension]]"
+  - "[[gh-cli-sub-issue-rfc]]"
+  - "[[github-fork-issues-discussion]]"
+---
+
+# Research: GitHub Issues as Harness Spec Storage
+
+## Overview
+
+GitHub Issues can serve as cloud-persistent, cross-session spec storage for the agentic harness. GitHub's native sub-issues (parent-child hierarchies, April 2025) and issue dependencies (blocked-by/blocking) map directly to the harness's spec decomposition and task dependency graphs. The `gh` CLI lacks native sub-issue support but a community extension (`gh-sub-issue`) fills the gap. A dual-tier architecture — local JSON cache + GitHub Issue ledger — gives speed and cloud persistence without over-reliance on network.
+
+## Key Findings
+
+- **GitHub has native sub-issues since April 2025**: Up to 8 levels deep, 100 sub-issues per parent, cross-repo support (Source: [[github-sub-issues-docs]])
+- **Issue dependencies are a separate feature**: Blocked-by / blocking relationships define execution order, distinct from sub-issues which define decomposition (Source: [[github-issue-dependencies-docs]])
+- **`gh` CLI has NO native sub-issue support**: cli/cli#10298 open since Jan 2025, PR #13057 in progress. Currently requires REST API or community extension (Source: [[gh-cli-sub-issue-rfc]])
+- **Community extension `gh-sub-issue`** (yahsan2): 110 stars, MIT, provides `add`/`create`/`list`/`remove` commands for parent-child relationships via `gh` CLI (Source: [[gh-sub-issue-extension]])
+- **Each hardened spec maps 1:1 to a GitHub Issue** with template body, labels for machine-readable state, and sub-issues for decomposed tasks
+- **Dual-tier architecture recommended**: Local `.pi/harness/specs/<id>.json` for speed, GitHub Issue for cross-session ledger
+- **Fork isolation is handled automatically**: Forks get their own issue tracker (enabled Dec 2025). Spec cache is gitignored — no stale upstream references leak into forks. `ultimate-pi harness init` bootstraps a fork's issue tracker with labels + templates
+
+## Key Entities
+
+- [[github-sub-issues-docs|GitHub Sub-Issues Feature]]: Native parent-child issue hierarchies in GitHub Issues
+- [[gh-sub-issue-extension|gh-sub-issue Extension]]: Community `gh` CLI extension (110 stars, MIT) bridging the CLI gap
+- [[gh-cli-sub-issue-rfc|gh CLI Sub-Issue RFC]]: cli/cli#10298 — official feature request for `--parent` on `gh issue create`
+
+## Key Concepts
+
+- **Sub-Issue vs Dependency**: Sub-issues = decomposition ("A contains B"). Dependencies = execution order ("A blocks B"). Both are native GitHub features with separate APIs.
+- **Dual-Tier Architecture**: Local cache (fast, offline-capable) + remote ledger (persistent, queryable). Local JSON is always the primary execution path. GitHub Issues are created at major state transitions only.
+- **Issue-as-Spec Template**: A HardenedSpec maps to an issue body with structured sections (intent_summary, success_criteria, anti_criteria, definition_of_done). Labels encode machine-readable state (`harness-spec`, `layer-{n}`, `status:{status}`).
+- **Execution Ledger**: Issue comments serve as an immutable audit trail. Each harness phase appends a status update comment.
+- **Phase-to-Issue Mapping**: Not every micro-step creates an issue. Only major state transitions: spec creation (P1), plan creation (P2), phase completion checkpoints (P8).
+
+## Contradictions
+
+None identified. All sources agree on the sub-issue feature's existence and CLI gap.
+
+## Fork / Multi-Tenant Considerations
+
+When someone forks a project using ultimate-pi, spec storage must not leak upstream state into the fork.
+
+### The Fork Problem
+
+1. **Issue tracker isolation**: GitHub historically blocked issues on forks. As of December 2025, forks CAN enable issues (Settings → General → Features → check "Issues"). But they start EMPTY — upstream issues are never copied to forks (Source: [[github-fork-issues-discussion]]).
+2. **Local cache leakage**: `.pi/harness/specs/<id>.json` files committed to the repo WOULD be forked, carrying stale upstream issue URLs. This is the primary contamination vector.
+3. **`gh` CLI context**: `gh` is authenticated to a specific repo. A fork must re-authenticate (`gh auth login`) and set its own default repo.
+
+### Solution: Local-First, Gitignored Cache, Init Bootstrap
+
+| Concern | Solution |
+|---------|----------|
+| Stale cache in forks | `.pi/harness/specs/` is in `.gitignore`. Cache is runtime-only, never committed. |
+| Empty issue tracker on fork | `ultimate-pi harness init` detects fork, prompts to enable issues (or auto-enables via API), creates harness label set |
+| Wrong `gh` repo context | `harness init` runs `gh repo set-default` for the fork. Config stored in `.pi/harness/config.json` (repo-relative, not global) |
+| Upstream spec references | Local cache stores `github_issue_url` as optional field. If absent or pointing to wrong repo, harness creates new issues in current repo |
+| No `gh` auth on fork | `harness init` checks `gh auth status`, guides user through `gh auth login` if needed |
+
+### Init Flow for Forked Projects
+
+```
+ultimate-pi harness init
+  ├─ Detect: is this a fork? (gh repo view --json isFork)
+  ├─ Check: are issues enabled? If not → guide to enable or auto-enable via API
+  ├─ Auth: gh auth status → prompt login if missing
+  ├─ Labels: gh label create harness-spec, harness-task, layer-1..layer-8, status:*
+  ├─ Templates: create .github/ISSUE_TEMPLATE/harness-spec.yml
+  ├─ Gitignore: ensure .pi/harness/specs/ is in .gitignore
+  └─ Ready: harness can now create spec issues in fork's own tracker
+```
+
+### Why This Works
+
+- **No shared state between upstream and fork**: Each has its own isolated issue tracker
+- **Gitignored cache prevents stale refs**: Fork never sees upstream's runtime spec files
+- **Init is idempotent**: Running `harness init` on an already-initialized fork is a no-op
+- **Labels are the only shared artifact**: Label names are convention, not data. Forks recreate them locally
+
+## Creative Solution: Content-Addressed Spec Identity
+
+The fork-merge divergence problem (fork #5 ≠ upstream #5) is solved via **content-addressed spec identity** combined with **GitHub's native issue transfer API**. See [[content-addressed-spec-identity]] for full specification.
+
+### How It Works
+
+1. **Every HardenedSpec gets a content fingerprint**: `SHA256(intent_summary + success_criteria + definition_of_done)`. Embedded in issue body as `<!-- spec-fp: <hash> -->`, in title as `[spec:<first8>]`, and in local cache.
+
+2. **Resolution by hash, not number**: When harness needs a spec, it searches `gh search issues "spec-fp:<hash>"` across all repos. Issue number is irrelevant — found by content identity, not location.
+
+3. **Transfer on merge**: `ultimate-pi harness migrate` uses `gh issue transfer` (native GitHub API) to move specs from fork to upstream. Idempotent — searches by fingerprint before transferring.
+
+4. **Transfer-safe**: When an issue transfers between repos, only its number changes. The body (and fingerprint within it) stays the same. Labels must be reapplied (GitHub limitation).
+
+### Why Content Addressing
+
+- **Repo-agnostic**: Same hash resolves to correct issue in any repo
+- **Deduplication**: Two issues with same fingerprint ARE the same spec — merge them
+- **No stale references**: Harness searches by hash, not by cached URL
+- **Inspired by Git's object model**: Content identity > location identity
+
+### Migration Flow
+
+```
+ultimate-pi harness migrate
+  ├─ Detect repo change (fork → upstream)
+  ├─ List fork specs by label
+  ├─ For each: search upstream by fingerprint
+  ├─ If not found → gh issue transfer + relabel
+  ├─ Update local cache URLs
+  └─ Idempotent — safe to re-run
+```
+
+Implementation effort: ~2-3 days. All operations use existing `gh` CLI.
+
+## Open Questions
+
+- When will `gh` CLI gain native `--parent` flag? PR #13057 in progress but no merge timeline.
+- What rate limiting impact will harness-driven issue creation have? 5,000 req/hr for authenticated users. At 1 issue per subtask, a 5-subtask plan creates ~5-15 issues — well within limits.
+- Should issue creation be synchronous during harness execution, or batched after pipeline completion?
+- Can GitHub Projects v2 auto-track sub-issue progress for harness observability (L5)?
+- Should `harness init` auto-enable issues on fork via API, or require manual user action? (API approach is faster but may surprise users)
+- ~~What happens if a fork is later merged upstream?~~ **SOLVED**: Content-addressed spec identity + `gh issue transfer` migration. See [[content-addressed-spec-identity]].
+
+## Integration Points
+
+### L1 Spec Hardening → GitHub Issues
+
+| Step | Action | CLI Command |
+|------|--------|-------------|
+| 1 | Harden spec | `SpecHardener.harden()` → HardenedSpec |
+| 2 | Create spec issue | `gh issue create --title "Spec: {intent_summary}" --body "..." --label harness-spec,layer-1` |
+| 3 | Store local cache | `.pi/harness/specs/{issue_number}.json` with `github_issue_url` field |
+| 4 | Emit spec_hardened | → L2 |
+
+### L2 Structured Planning → GitHub Sub-Issues
+
+| Action | CLI Command |
+|--------|-------------|
+| Create task sub-issues | `gh sub-issue create --parent {spec_issue} --title "{task_name}" --label harness-task` |
+| Link dependencies | `gh issue edit {task_A} --add-label "blocked-by:{task_B}"` (or use API for native deps) |
+| Add sprint contract | `gh issue comment {task_issue} --body "## Sprint Contract\n..."` |
+
+### GitHub Projects v2 (Optional Visualization)
+
+- Add spec issue to a "Harness" project board
+- Sub-issues auto-appear in board with parent/child progress fields
+- Filter by `label:harness-spec`, group by `status`
+- Roadmap view for phase timelines
+
+## Toolchain
+
+| Tool | Purpose | Command |
+|------|---------|---------|
+| `gh issue create` | Create spec/task issues | `gh issue create --title "..." --body "..." --label ...` |
+| `gh issue edit` | Update issue state/labels | `gh issue edit {id} --add-label "..." --remove-label "..."` |
+| `gh issue comment` | Append execution log entry | `gh issue comment {id} --body "..."` |
+| `gh issue list` | Query issue state | `gh issue list --label harness-spec --json number,title,state,labels` |
+| `gh issue view` | Read issue body as JSON | `gh issue view {id} --json body,title,labels,state` |
+| `gh sub-issue create` | Create child task | `gh sub-issue create --parent {id} --title "..."` |
+| `gh sub-issue list` | List child tasks | `gh sub-issue list {id} --json number,title,state` |
+| `gh api` | Raw API for dependencies | `gh api /repos/{owner}/{repo}/issues/{id}` |
+
+## Sources
+
+- [[github-sub-issues-docs]]: GitHub official docs on sub-issues (April 2025)
+- [[github-issue-dependencies-docs]]: GitHub official docs on issue dependencies
+- [[gh-sub-issue-extension]]: yahsan2/gh-sub-issue, MIT license, v0.5.1 (Oct 2025)
+- [[gh-cli-sub-issue-rfc]]: cli/cli#10298, feature request (Jan 2025)
+- [[github-fork-issues-discussion]]: GitHub Community discussion #161368 — fork issues enablement (Jun-Dec 2025)

--- a/vault/wiki/sources/gh-cli-sub-issue-rfc.md
+++ b/vault/wiki/sources/gh-cli-sub-issue-rfc.md
@@ -1,0 +1,48 @@
+---
+type: source
+source_type: github-issue
+title: "gh CLI Feature Request: Parent Issues / Sub-Tasks Support"
+author: premun (cli/cli)
+date_published: 2025-01-23
+url: https://github.com/cli/cli/issues/10298
+confidence: high
+key_claims:
+  - "`gh` CLI does not currently support setting parent issues / sub-tasks on issue create/edit"
+  - "Feature request: --set-parent [ID] and --unset-parent [ID] flags on gh issue"
+  - "Linked to PR #13057 (in progress as of April 2026)"
+  - "Labeled: core (not accepting outside PRs), enhancement, gh-issue, needs-product"
+tags:
+  - github
+  - cli
+  - feature-request
+  - sub-issues
+related:
+  - "[[Research: GitHub Issues as Harness Spec Storage]]"
+  - "[[gh-sub-issue-extension]]"
+---
+
+# gh CLI Feature Request: Parent Issues / Sub-Tasks
+
+Official feature request on `cli/cli` repo (44.2k stars) requesting native sub-issue support in `gh issue create` and `gh issue edit`.
+
+## Status
+
+- **Opened**: January 23, 2025
+- **Status**: Open (as of April 2026)
+- **Labels**: `core` (not accepting PRs from outside contributors), `enhancement`, `gh-issue`, `needs-product`
+- **PR**: [#13057](https://github.com/cli/cli/pull/13057) — linked, in development
+
+## Proposed Solution
+
+```bash
+# Create issue with parent
+gh issue create --title "..." --set-parent 123
+
+# Edit existing issue
+gh issue edit 456 --set-parent 123
+gh issue edit 456 --unset-parent
+```
+
+## Harness Impact
+
+When native support lands in `gh` CLI, the harness can drop the `gh-sub-issue` extension dependency and use `gh issue create --parent` directly. Until then, the extension or raw `gh api` GraphQL calls are required.

--- a/vault/wiki/sources/gh-sub-issue-extension.md
+++ b/vault/wiki/sources/gh-sub-issue-extension.md
@@ -1,0 +1,70 @@
+---
+type: source
+source_type: github-repo
+title: "gh-sub-issue: GitHub CLI Extension for Sub-Issues"
+author: yahsan2
+date_published: 2025
+url: https://github.com/yahsan2/gh-sub-issue
+confidence: high
+key_claims:
+  - "Community `gh` CLI extension for managing sub-issues (parent-child relationships)"
+  - "Supports add, create, list, remove operations on sub-issues"
+  - "Uses GitHub GraphQL API under the hood, not custom reference schemes"
+  - "Cross-repository support"
+  - "JSON output for machine readability"
+  - "110 stars, 35 commits, MIT license"
+  - "Non-destructive: links existing issues without closing or recreating them"
+tags:
+  - github
+  - cli
+  - sub-issues
+  - gh-extension
+related:
+  - "[[Research: GitHub Issues as Harness Spec Storage]]"
+  - "[[gh-cli-sub-issue-rfc]]"
+---
+
+# gh-sub-issue: GitHub CLI Extension for Sub-Issues
+
+Community `gh` CLI extension (110 stars, MIT) bridging the gap where `gh` CLI lacks native sub-issue support.
+
+## Commands
+
+| Command | Purpose |
+|---------|---------|
+| `gh sub-issue add <parent> <child>` | Link existing issue as child of parent |
+| `gh sub-issue create --parent <id> --title "..."` | Create new child issue |
+| `gh sub-issue list <parent>` | List all children of a parent |
+| `gh sub-issue remove <parent> <child>` | Unlink child from parent |
+
+## Key Features
+
+- **JSON output**: `--json number,title,state,labels` for machine parsing
+- **Cross-repo**: `--repo owner/repo` to work across repositories
+- **Force remove**: `--force` to skip confirmation prompts
+- **Output formats**: TTY (colored), plain text, JSON
+- **Non-destructive**: Uses native GitHub sub-issue relationships, not custom reference schemes
+
+## Installation
+
+```bash
+gh extension install yahsan2/gh-sub-issue
+```
+
+Requirements: `gh` CLI 2.0.0+, GitHub account with repo write access.
+
+## Harness Integration
+
+This extension is the primary CLI tool for creating harness task sub-issues from L2 structured planning. Example harness workflow:
+
+```bash
+# Create spec issue
+SPEC_ID=$(gh issue create --title "Spec: Add user auth" --body "..." --label harness-spec,layer-1 --json number -q .number)
+
+# Create task sub-issues
+gh sub-issue create --parent $SPEC_ID --title "P1: Design DB schema" --label harness-task
+gh sub-issue create --parent $SPEC_ID --title "P2: Implement JWT tokens" --label harness-task
+
+# Check progress
+gh sub-issue list $SPEC_ID --json number,title,state
+```

--- a/vault/wiki/sources/github-fork-issues-discussion.md
+++ b/vault/wiki/sources/github-fork-issues-discussion.md
@@ -1,0 +1,42 @@
+---
+type: source
+source_type: github-discussion
+title: "GitHub Community: No Issues to Enable in Forked Repo"
+author: guangli-dai, tarak6984, secretnamebasis
+date_published: 2025-06-02
+url: https://github.com/orgs/community/discussions/161368
+confidence: high
+key_claims:
+  - "GitHub historically blocked enabling Issues on forked repositories independently"
+  - "As of June 2025, users reported no Issues checkbox in fork Settings > General > Features"
+  - "As of December 2025, a user confirmed Issues CAN be enabled on forks via Settings"
+  - "Workaround for older/restricted forks: create new repo, use Discussions, or external trackers"
+  - "Issue tracking is designed to be centralized in the original repo; forks are copies for contribution, not independent projects"
+tags:
+  - github
+  - fork
+  - issues
+  - multi-tenant
+related:
+  - "[[Research: GitHub Issues as Harness Spec Storage]]"
+---
+
+# GitHub Community: Fork Issues Discussion
+
+GitHub Community discussion #161368 tracking the evolution of issue support on forked repositories.
+
+## Timeline
+
+| Date | Event |
+|------|-------|
+| Jun 2, 2025 | `guangli-dai` reports: No "Issues" checkbox in fork's Settings → Features |
+| Jun 3, 2025 | `tarak6984` confirms: "GitHub currently does NOT allow enabling Issues on forked repositories independently" |
+| Dec 30, 2025 | `secretnamebasis` reports: "Under /settings there is a way to check the issues box on a fork" — feature added |
+
+## Relevance to Harness
+
+Forks of ultimate-pi projects need their own issue tracker for spec storage. This discussion confirms:
+1. **Forks CAN now enable issues** (post-Dec 2025). No fundamental blocker.
+2. **Upstream issues are never copied** — each fork starts with a clean slate.
+3. **`gh` CLI must be reconfigured** for the fork's repo, not upstream.
+4. **Local cache isolation is critical** — `.pi/harness/specs/` must be gitignored to prevent stale upstream refs from leaking into forks.

--- a/vault/wiki/sources/github-issue-dependencies-docs.md
+++ b/vault/wiki/sources/github-issue-dependencies-docs.md
@@ -1,0 +1,47 @@
+---
+type: source
+source_type: documentation
+title: "GitHub Issue Dependencies — Official Documentation"
+author: GitHub Docs
+date_published: 2025-04
+url: https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/creating-issue-dependencies
+confidence: high
+key_claims:
+  - "Issue dependencies define blocked-by and blocking relationships between issues"
+  - "Dependencies are distinct from sub-issues — they define execution order, not decomposition"
+  - "Blocked issues show a Blocked icon on project boards and Issues page"
+  - "Available on Free, Pro, Team, and Enterprise Cloud plans"
+  - "Requires at least triage permissions"
+tags:
+  - github
+  - issues
+  - dependencies
+  - project-management
+related:
+  - "[[Research: GitHub Issues as Harness Spec Storage]]"
+  - "[[github-sub-issues-docs]]"
+---
+
+# GitHub Issue Dependencies — Official Documentation
+
+GitHub's official documentation for issue dependencies (blocked-by / blocking relationships).
+
+## Key Capabilities
+
+- **Blocked by**: Mark an issue as dependent on another issue's completion
+- **Blocking**: Mark an issue as preventing another from progressing
+- **Visual indicators**: Blocked icon on project boards and Issues list
+- **Multiple dependencies**: An issue can be blocked by multiple issues, and block multiple issues
+
+## Distinction from Sub-Issues
+
+| Feature | Sub-Issues | Dependencies |
+|---------|------------|--------------|
+| Relationship | Parent-child (decomposition) | Blocked-by / blocking (ordering) |
+| Progress roll-up | Automatic (parent shows child completion %) | Manual (no auto-status from deps) |
+| Hierarchical limit | 8 levels deep | No depth limit (graph) |
+| Per-parent limit | 100 children | No limit |
+
+## Relevance to Harness
+
+L2 Structured Planning produces a task DAG. Dependencies map the DAG edges — "Task B cannot start until Task A completes." Sub-issues map the tree structure — "Spec S decomposes into Tasks A, B, C." Both are needed for full task topology.

--- a/vault/wiki/sources/github-sub-issues-docs.md
+++ b/vault/wiki/sources/github-sub-issues-docs.md
@@ -1,0 +1,49 @@
+---
+type: source
+source_type: documentation
+title: "GitHub Sub-Issues — Official Documentation"
+author: GitHub Docs
+date_published: 2025-04-11
+url: https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/adding-sub-issues
+confidence: high
+key_claims:
+  - "Sub-issues allow breaking larger issues into smaller tasks, available since April 2025"
+  - "Up to 100 sub-issues per parent issue and up to 8 levels of nested sub-issues"
+  - "Parent issues and sub-issue progress is available in GitHub Projects (filter, group, views)"
+  - "Sub-issues can themselves contain sub-issues (full hierarchies)"
+  - "Cross-repository sub-issues supported"
+  - "Requires at least triage permissions"
+tags:
+  - github
+  - issues
+  - sub-issues
+  - project-management
+related:
+  - "[[Research: GitHub Issues as Harness Spec Storage]]"
+---
+
+# GitHub Sub-Issues — Official Documentation
+
+GitHub's official documentation for the sub-issues feature, launched in April 2025.
+
+## Key Capabilities
+
+- **Parent-child hierarchies**: Break larger issues into manageable tasks
+- **Depth**: Up to 8 levels of nesting
+- **Breadth**: Up to 100 sub-issues per parent
+- **Cross-repo**: Sub-issues can live in different repositories
+- **Projects integration**: Progress fields, filters, grouping by parent issue
+- **Two creation modes**: Create new sub-issue inline, or add existing issue as child
+
+## API Layer
+
+Sub-issues are exposed through GitHub's GraphQL API with dedicated fields:
+- `subIssues` — list of child issues
+- `parent` — parent issue reference
+- `subIssuesSummary` — aggregate progress (total, completed, not_planned)
+
+The REST API also supports sub-issue relationships through the issues endpoint with parent/child fields.
+
+## Relevance to Harness
+
+This is the canonical cloud storage mechanism for spec decomposition. Each hardened spec (L1) becomes a parent issue; each task from structured planning (L2) becomes a sub-issue. Progress auto-rolls up from children to parent.


### PR DESCRIPTION
- Research synthesis: GitHub Issues as cloud-persistent harness spec storage
- Concept pages: content-addressed spec identity (SHA256 fingerprinting), fork-safe spec storage (gitignored cache + init bootstrap)
- 5 source pages ingested: gh sub-issues, dependencies, fork enablement, gh-sub-issue extension, gh CLI RFC
- Cleaned skills-lock.json: removed 7 unused skill entries (compress, cross-linker, data-ingest, emil-design-eng, graph-colorize, ingest-url, json-canvas)
- Updated wiki index, hot cache, and operations log