### PR TITLE
fix(firecrawl): remove SELinux :Z label from searxng settings bind mount

### DIFF
--- a/firecrawl/docker-compose.yaml
+++ b/firecrawl/docker-compose.yaml
@@ -181,7 +181,7 @@ services:
       - backend
     env_file: ./searxng/searxng.env
     volumes:
-      - ./searxng/settings.yml:/etc/searxng/settings.yml:Z
+      - ./searxng/settings.yml:/etc/searxng/settings.yml
       - searxng-data:/var/cache/searxng
     depends_on:
       - searxng-valkey


### PR DESCRIPTION
- Docker Desktop on WSL cannot resolve SELinux-labeled bind mounts
- Caused "no such file or directory" error on searxng container startup
- All 7 containers now start successfully after removing :Z flag