### PR TITLE
docs(harness): restructure README for end users, add CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,116 @@
+# Contributing to ultimate-pi
+
+## Local development setup
+
+1. Clone and install dependencies:
+
+   ```bash
+   git clone https://github.com/aryaniyaps/ultimate-pi.git
+   cd ultimate-pi
+   npm install
+   ```
+
+   `npm install` automatically sets up pre-commit hooks via [Lefthook](https://github.com/evilmartians/lefthook).
+
+2. Install the package locally into PI:
+
+   ```bash
+   pi install . -l
+   ```
+
+   Then restart PI or run `/reload`.
+
+## Linting & formatting
+
+Uses [Biome](https://biomejs.dev) for linting, formatting, and import sorting.
+
+```bash
+npm run lint            # check lint + format errors
+npm run lint:fix        # auto-fix lint + format errors
+npm run format          # format all files
+npm run format:check    # check formatting without writing
+npm run check:ts        # typecheck extensions
+```
+
+Pre-commit hooks run `biome check` and `tsc` on staged files automatically.
+
+## Firecrawl (self-hosted web scraping)
+
+The Firecrawl skill depends on a Firecrawl instance. This repo includes a self-hosted setup powered by Docker.
+
+### Quick start
+
+```bash
+cd firecrawl
+cp .env.template .env   # first time only — edit if needed
+docker compose up -d     # pulls pre-built GHCR images automatically
+```
+
+Firecrawl API is now at `http://localhost:3002`. Admin UI at `http://localhost:3002/admin/<BULL_AUTH_KEY>/queues`.
+
+### Services
+
+| Service | Image | Port |
+|---------|-------|------|
+| `api` | `ghcr.io/firecrawl/firecrawl` | 3002 |
+| `playwright-service` | `ghcr.io/firecrawl/playwright-service:latest` | 3000 (internal) |
+| `nuq-postgres` | `ghcr.io/firecrawl/nuq-postgres:latest` | 5432 (internal) |
+| `redis` | `redis:alpine` | 6379 (internal) |
+| `rabbitmq` | `rabbitmq:3-management` | 5672 (internal) |
+| `searxng` | `searxng/searxng:latest` | 8080 |
+
+### Configuration
+
+All options live in `firecrawl/.env`. See `firecrawl/.env.template` for the full reference. Key env vars:
+
+- `PORT` — API port (default: `3002`)
+- `SEARXNG_ENDPOINT` — enables `/search` API (default: `http://searxng:8080`)
+- `OPENAI_API_KEY` — enables AI features (JSON formatting, `/extract` API)
+- `BULL_AUTH_KEY` — admin UI access key (default: `CHANGEME` — change in production)
+
+See `firecrawl/README.md` for detailed docs and SDK usage examples.
+
+## Extensions
+
+### Dotenv loader
+
+`.pi/extensions/dotenv-loader.ts` — loads `.env` files into `process.env` on session start.
+
+Configurable via env vars (set before launching pi):
+
+| Variable | Default | Description |
+|---|---|---|
+| `ENV_LOADER_FILES` | `.env` | Comma-separated list of `.env` file paths (relative to cwd). |
+| `ENV_LOADER_OVERRIDE` | `false` | Set to `true` to overwrite existing env vars. |
+| `ENV_LOADER_SILENT` | `false` | Set to `true` to suppress startup logs. |
+| `ENV_LOADER_ENCODING` | `utf-8` | File encoding for `.env` files. |
+
+- Supports variable expansion (`$VAR` and `${VAR}`).
+- Reloads on `/reload`.
+- Status command: `/env-loader-status`
+
+### PostHog analytics
+
+`@posthog/pi` — wraps the upstream [posthog-pi](https://github.com/PostHog/posthog-pi) extension to capture AI generation spans, tool spans, and traces in [PostHog](https://posthog.com). Install via `pi install @posthog/pi`. See the upstream repo for configuration and env vars.
+
+## Skill sources
+
+| Skill | Upstream |
+|---|---|
+| caveman | [juliusbrussee/caveman](https://github.com/juliusbrussee/caveman) |
+| context7-cli | [upstash/context7](https://github.com/upstash/context7) |
+| find-skills | bundled (context7-compatible discovery) |
+| firecrawl (13 skills) | [firecrawl](https://firecrawl.dev) |
+| obsidian/wiki skills (11 skills) | [AgriciDaniel/claude-obsidian](https://github.com/AgriciDaniel/claude-obsidian) |
+| posthog-analyst | bundled (PostHog MCP integration) |
+| defuddle | bundled (web content cleaning) |
+
+### Firecrawl sub-skills
+
+`firecrawl-search`, `firecrawl-scrape`, `firecrawl-crawl`, `firecrawl-map`, `firecrawl-download`, `firecrawl-parse`, `firecrawl-interact`, `firecrawl-agent`, `firecrawl-build-scrape`, `firecrawl-build-search`, `firecrawl-build-onboarding`, `firecrawl-build-interact`
+
+### Wiki sub-skills
+
+`wiki`, `wiki-save`, `wiki-query`, `wiki-ingest`, `wiki-lint`, `wiki-fold`, `autoresearch`, `canvas`, `obsidian-markdown`, `obsidian-bases`
+
+> `lean-ctx` is installed as a separate pi package (`pi-lean-ctx`) — not bundled as a skill.

--- a/README.md
+++ b/README.md
@@ -1,179 +1,71 @@
 ![Ultimate PI banner](https://raw.githubusercontent.com/aryaniyaps/ultimate-pi/main/.github/banner-v2.png)
 
-> (Beta) The **ultimate AI coding harness** on top of [**pi.dev**](https://pi.dev).
+> The **ultimate AI coding harness** on top of [**pi.dev**](https://pi.dev).
 
 ## Goal
 
-Ship a production-grade coding harness where the agent:
-1. uses compressed context before raw tool spam,
-2. stays concise and deterministic in output style,
-3. remains easy to extend with skills and extensions.
+A production-grade coding harness where the agent:
+1. Uses compressed context before raw tool spam,
+2. Stays concise and deterministic in output style,
+3. Is easy to extend with skills and extensions.
 
 ## Getting started
 
-1. Install from npm:
+```bash
+npm install -g ultimate-pi
+```
 
-   ```bash
-   npm install -g ultimate-pi
-   ```
-
-2. Install package into PI from your project folder:
-
-   ```bash
-   pi install ultimate-pi -l
-   ```
-
-3. Reload PI to activate skills and extensions:
-
-   ```bash
-   /reload
-   ```
-
-4. Optional: install from GitHub Packages instead:
-
-   ```bash
-   npm install -g @aryaniyaps/ultimate-pi --registry=https://npm.pkg.github.com
-   ```
-
-## Firecrawl self-hosted (web scraping infra)
-
-The Firecrawl skill depends on a Firecrawl instance. This repo includes a self-hosted
-setup powered by Docker — no separate repo clone needed.
-
-### Quick start
+From your project folder:
 
 ```bash
-cd firecrawl
-cp .env.template .env   # first time only — edit if needed
-docker compose up -d     # pulls pre-built GHCR images automatically
+pi install ultimate-pi -l
 ```
 
-Firecrawl API is now at `http://localhost:3002`. Admin UI at
-`http://localhost:3002/admin/<BULL_AUTH_KEY>/queues`.
+Then reload PI:
 
-### Services
-
-| Service | Image | Port |
-|---------|-------|------|
-| `api` | `ghcr.io/firecrawl/firecrawl` | 3002 |
-| `playwright-service` | `ghcr.io/firecrawl/playwright-service:latest` | 3000 (internal) |
-| `nuq-postgres` | `ghcr.io/firecrawl/nuq-postgres:latest` | 5432 (internal) |
-| `redis` | `redis:alpine` | 6379 (internal) |
-| `rabbitmq` | `rabbitmq:3-management` | 5672 (internal) |
-| `searxng` | `searxng/searxng:latest` | 8080 |
-
-### Configuration
-
-All options live in `firecrawl/.env`. See `firecrawl/.env.template` for the full
-reference. Key env vars:
-
-- `PORT` — API port (default: `3002`)
-- `SEARXNG_ENDPOINT` — enables `/search` API (default: `http://searxng:8080`)
-- `OPENAI_API_KEY` — enables AI features (JSON formatting, `/extract` API)
-- `BULL_AUTH_KEY` — admin UI access key (default: `CHANGEME` — change in production)
-
-See `firecrawl/README.md` for detailed docs and SDK usage examples.
-
-## Obsidian wiki setup
-
-### Step 1 — Run `wiki`
-
-Inside your PI session, run:
-
-```
-/wiki
+```bash
+/reload
 ```
 
-This skill walks you through the rest automatically — creating the folder structure, special files (`Home.md`, `log.md`, `hot.md`), `.gitignore`, and `.obsidian` config. It stays in sync with the skill definition, so you always get the latest structure without manually mirroring docs here.
+Optional: install from GitHub Packages:
 
-### Step 2 — Open in Obsidian
+```bash
+npm install -g @aryaniyaps/ultimate-pi --registry=https://npm.pkg.github.com
+```
 
-1. Open Obsidian → **File → Open Vault** → select your vault directory (e.g. `~/wiki/ultimate-pi`)
-2. Install recommended community plugins:
-   - **Dataview** — query page metadata, dynamic tables
-   - **Graph Analysis** — enhanced graph view
-   - **Obsidian Git** — auto-commit and push vault to the wiki repo
+## Bootstrap
+
+Run the harness setup prompt to configure everything (wiki, firecrawl, env vars, extensions):
+
+```
+/harness-setup
+```
+
+## Wiki
+
+The harness includes an Obsidian wiki vault as its knowledge layer. Run `/wiki` in your PI session to scaffold it, then open the vault in [Obsidian](https://obsidian.md). Recommended community plugins: Dataview, Graph Analysis, Obsidian Git.
 
 ## Included skills
 
-### Core skills (upstream repositories)
-
-| Skill | Upstream | What it does |
-|---|---|---|
-| caveman | [juliusbrussee/caveman](https://github.com/juliusbrussee/caveman) | Ultra-compressed response style. Cuts token usage ~75%. |
-| lean-ctx | [yvgude/lean-ctx](https://github.com/yvgude/lean-ctx) | Context runtime — 46 MCP tools, 10 read modes, tree-sitter AST. Compresses context up to 99%. |
-| context7-cli | [upstash/context7](https://github.com/upstash/context7) | Fetch current library docs, manage Context7 skills/config. |
-| firecrawl | [firecrawl](https://firecrawl.dev) | Web search, scraping, crawling, JS rendering, site downloads, interactive pages. |
-
-### Obsidian wiki skills (11 skills)
-
-Installed via `npx skills add AgriciDaniel/claude-obsidian --yes` or bundled:
-
 | Skill | What it does |
 |---|---|
-| autoresearch | Research topic and file to wiki. |
-| canvas | Work with JSON canvas. |
-| obsidian-bases | Create database-like views. |
-| obsidian-markdown | Edit Obsidian flavored markdown. |
-| wiki-save | Save conversation to wiki. |
-| wiki | Add links to orphan files. |
-| wiki-fold | Create index files for folders. |
-| wiki-ingest | Distill sources to wiki. |
-| wiki-lint | Check for broken links/orphans. |
-| wiki-query | Answer questions via wiki search. |
-| defuddle | Extract clean markdown from web pages, stripping clutter. |
+| **caveman** | Ultra-compressed response style (~75% token savings). |
+| **context7-cli** | Fetch library docs, manage Context7 skills/config. |
+| **find-skills** | Discover and install new agent skills. |
+| **firecrawl** | Web search, scraping, crawling, JS rendering, interactive pages, structured extraction, site downloads. |
+| **autoresearch** | Autonomous deep research filed to the wiki. |
+| **wiki** | Scaffold and manage the Obsidian wiki vault. |
+| **wiki-save** | Save conversations and insights to the wiki. |
+| **wiki-query** | Answer questions using the wiki vault. |
+| **wiki-ingest** | Distill external sources into wiki pages. |
+| **wiki-lint** | Health-check the wiki (orphans, dead links, stale claims). |
+| **wiki-fold** | Rollup log entries into meta-pages. |
+| **defuddle** | Strip web page clutter to clean markdown. |
+| **canvas** | Work with Obsidian JSON canvas files. |
+| **obsidian-markdown** | Correct Obsidian-flavored markdown editing. |
+| **obsidian-bases** | Create database-like views over vault notes. |
+| **posthog-analyst** | Analyze agent performance via PostHog MCP. |
 
-### Dotenv loader extension
+## Contributing
 
-- `.pi/extensions/dotenv-loader.ts`
-  - Loads `.env` files into `process.env` on session start, before other extensions read their config.
-  - Ensures extensions like `@posthog/pi` can pick up env vars from `.env` automatically.
-  - Configurable via env vars (set before launching pi):
-
-| Variable | Default | Description |
-|---|---|---|
-| `ENV_LOADER_FILES` | `.env` | Comma-separated list of `.env` file paths (relative to cwd). |
-| `ENV_LOADER_OVERRIDE` | `false` | Set to `true` to overwrite existing env vars. |
-| `ENV_LOADER_SILENT` | `false` | Set to `true` to suppress startup logs. |
-| `ENV_LOADER_ENCODING` | `utf-8` | File encoding for `.env` files. |
-
-  - Supports variable expansion (`$VAR` and `${VAR}`) referencing current `process.env`.
-  - Reloads on `/reload`.
-  - Status command: `/env-loader-status`
-
-### PostHog analytics extension
-
-- `@posthog/pi` (installed via `pi install @posthog/pi`)
-  - Wraps the upstream [posthog-pi](https://github.com/PostHog/posthog-pi) extension to capture AI generation spans, tool spans, and traces in [PostHog](https://posthog.com). See the upstream repo for configuration and env vars.
-
-1. Clone and install dependencies:
-
-   ```bash
-   git clone https://github.com/aryaniyaps/ultimate-pi.git
-   cd ultimate-pi
-   npm install
-   ```
-
-   `npm install` automatically sets up pre-commit hooks via [Lefthook](https://github.com/evilmartians/lefthook).
-
-2. Install the package locally into PI:
-
-   ```bash
-   pi install . -l
-   ```
-
-   Then restart PI or run `/reload`.
-
-### Linting & formatting
-
-This project uses [Biome](https://biomejs.dev) for linting, formatting, and import sorting.
-
-```bash
-npm run lint            # check lint + format errors
-npm run lint:fix        # auto-fix lint + format errors
-npm run format          # format all files
-npm run format:check    # check formatting without writing
-npm run check:ts        # typecheck extensions
-```
-
-Pre-commit hooks run `biome check` and `tsc` on staged files automatically — no bad code gets committed.
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for local development setup, linting, and extension config details.


### PR DESCRIPTION
- Split README into user-facing essentials (install, bootstrap, skill list)
- Move dev setup, firecrawl infra, linting, extension config to CONTRIBUTING.md
- Remove stale lean-ctx entry (separate pi-lean-ctx package)
- Add find-skills and wiki to accurate skill list