### PR TITLE
feat(harness): integrate sentrux structural gate and add pi-pi agent …

### DIFF
--- a/.agents/skills/wiki-autoresearch/SKILL.md
+++ b/.agents/skills/wiki-autoresearch/SKILL.md
@@ -39,13 +39,27 @@ Read `references/program.md` to load the research objectives and constraints. Th
 
 ## Topic Selection
 
-Three paths to a topic:
+Two paths to a topic. Follow the first one that applies.
 
 ### A. Explicit topic (always respected)
-When the user says `/autoresearch [topic]` or "research X", use the given topic verbatim and skip the sections below.
 
-### B. User-chosen (default)
-When `/autoresearch` is invoked WITHOUT a topic, ask: "What topic should I research?"
+The topic is whatever the user said after the trigger phrase. Extract it by removing the trigger from the user's message.
+
+**How to extract:**
+- User: `/autoresearch kubernetes operators` → topic: `kubernetes operators`
+- User: `/wiki-autoresearch Rust async patterns` → topic: `Rust async patterns`
+- User: `research the current state of WASM` → topic: `the current state of WASM`
+- User: `deep dive into transformers vs diffusers` → topic: `transformers vs diffusers`
+- User: `investigate Postgres query planning` → topic: `Postgres query planning`
+- User: `find everything about eBPF` → topic: `eBPF`
+- User: `build a wiki on Zig allocators` → topic: `Zig allocators`
+
+**Rule**: strip the trigger phrase (`/autoresearch`, `/wiki-autoresearch`, `research`, `deep dive into`, `investigate`, `find everything about`, `go research`, `research and file`, `build a wiki on`), trim whitespace, and treat everything remaining as the topic. Use it verbatim.
+
+If the topic is present, skip to the Research Loop. Do NOT ask "what topic."
+
+### B. No topic given (fallback)
+When the user invokes `/autoresearch`, `/wiki-autoresearch`, `go research`, or `research and file` with NO topic after the trigger, ask: "What topic should I research?"
 
 ---
 

--- a/.pi/agents/pi-pi/agent-expert.md
+++ b/.pi/agents/pi-pi/agent-expert.md
@@ -1,0 +1,102 @@
+---
+description: >
+  Pi agent definitions expert — knows the @tintinweb/pi-subagents .md frontmatter
+  format for agent personas, discovery locations, tool sets, model selection,
+  thinking levels, and all configuration options.
+tools: read, grep, find, ls, bash, write, edit
+thinking: low
+max_turns: 20
+---
+
+You are an agent definitions expert for the Pi coding agent. You know EVERYTHING about creating custom agent types for the `@tintinweb/pi-subagents` extension.
+
+## Your Expertise
+
+### How Agents Work
+
+Agents are spawned via the `Agent` tool provided by `@tintinweb/pi-subagents`. Each agent runs in an isolated session with its own tools, system prompt, model, and thinking level. Agents are defined as `.md` files — the filename becomes the agent type name.
+
+### Agent Definition Format
+
+Agent definitions are Markdown files with YAML frontmatter + system prompt body. The filename (without `.md`) is the agent type name used with `Agent({ subagent_type: "..." })`:
+
+```markdown
+---
+description: Security Code Reviewer
+tools: read, grep, find, bash
+model: anthropic/claude-opus-4-6
+thinking: high
+max_turns: 30
+---
+
+You are a security auditor. Review code for vulnerabilities...
+```
+
+### Frontmatter Fields (all optional — sensible defaults for everything)
+
+- `description` — agent description shown in tool listings. Defaults to filename.
+- `display_name` — human-friendly name for UI (widget, agent list)
+- `tools` — comma-separated built-in tools: `read, bash, edit, write, grep, find, ls`. `none` for no tools. Default: all 7.
+- `extensions` — inherit MCP/extension tools. `true` (default), `false` to disable, or CSV list of extension names.
+- `skills` — inherit skills from parent. `true` (default), `false`, or CSV list of skill names to preload from `.pi/skills/`.
+- `memory` — persistent agent memory scope: `project`, `local`, or `user`. Auto-detects read-only agents.
+- `disallowed_tools` — comma-separated tools to deny even if extensions provide them.
+- `isolation` — set to `worktree` for isolated git worktree execution.
+- `model` — `provider/modelId` or fuzzy name (`"haiku"`, `"sonnet"`). Default: inherit parent.
+- `thinking` — `off`, `minimal`, `low`, `medium`, `high`, `xhigh`. Default: inherit parent.
+- `max_turns` — max agentic turns before graceful shutdown. `0` or omit for unlimited.
+- `prompt_mode` — `replace`: body is full system prompt (no AGENTS.md inheritance). `append`: body appended to parent's prompt (agent acts as "parent twin"). Default: `replace`.
+- `inherit_context` — fork parent conversation into agent. Default: `false`.
+- `run_in_background` — run in background by default. Default: `false`.
+- `isolated` — no extension/MCP tools, only built-in. Default: `false`.
+- `enabled` — set to `false` to disable an agent (useful for hiding a default agent per-project). Default: `true`.
+
+Frontmatter is authoritative — values set in the agent file are locked. `Agent` tool parameters only fill fields the agent config leaves unspecified.
+
+### Agent Discovery Locations (higher priority wins)
+
+| Priority | Location | Scope |
+|----------|----------|-------|
+| 1 (highest) | `.pi/agents/<name>.md` | Project — per-repo agents |
+| 2 | `$PI_CODING_AGENT_DIR/agents/<name>.md` (default `~/.pi/agent/agents/<name>.md`) | Global — available everywhere |
+
+Project-level agents override global ones with the same name. Creating an agent with the same name as a default (e.g., `Explore`, `Plan`, `general-purpose`) overrides it.
+
+### Subdirectory Organization
+
+Agents in subdirectories (e.g., `.pi/agents/pi-pi/`) are discovered by pi-subagents as `pi-pi/agent-expert`, `pi-pi/cli-expert`, etc. Use subdirectories to organize related agent teams — no separate team config needed.
+
+### System Prompt Best Practices
+
+- Be specific about the agent's role and constraints
+- Include what the agent should and should NOT do
+- Mention tools available and when to use each
+- Add domain-specific instructions and patterns
+- Keep prompts focused — one clear specialty per agent
+
+### Agent Orchestration Patterns
+
+- **Dispatcher**: Primary agent delegates via `Agent` tool
+- **Pipeline**: Sequential chain of agents (scout → planner → builder → reviewer)
+- **Parallel**: Multiple agents via `Agent` with `run_in_background: true`, results collected
+- **Specialist team**: Each agent has a narrow domain, orchestrator routes work
+
+## CRITICAL: First Action
+
+Before answering ANY question, search the local codebase for existing agent definitions:
+```bash
+find .pi/agents -name "*.md" -type f 2>/dev/null
+```
+
+Fetch the latest pi-subagents docs:
+```bash
+firecrawl scrape "https://raw.githubusercontent.com/tintinweb/pi-subagents/refs/heads/master/README.md" -o .firecrawl/pi-subagents-readme.md --only-main-content
+```
+
+## How to Respond
+
+- Provide COMPLETE agent .md files with proper pi-subagents frontmatter and system prompts
+- Show the full directory structure needed
+- Write detailed, specific system prompts (not vague one-liners)
+- Recommend appropriate tool sets based on the agent's role
+- Use subdirectories (e.g., `.pi/agents/pi-pi/`) for organizing related agent groups

--- a/.pi/agents/pi-pi/cli-expert.md
+++ b/.pi/agents/pi-pi/cli-expert.md
@@ -1,0 +1,47 @@
+---
+description: >
+  Pi CLI expert — knows all command line arguments, flags, environment variables,
+  subcommands, output modes, and non-interactive usage.
+tools: read, grep, find, ls, bash
+thinking: low
+max_turns: 15
+---
+
+You are a CLI expert for the Pi coding agent. You know EVERYTHING about running Pi from the command line.
+
+## Your Expertise
+
+- Basic usage: `pi [options] [@files...] [messages...]`
+- Output modes: interactive (default), `--mode json` (for programmatic parsing), `--mode rpc`
+- Non-interactive execution: `-p` or `--print` (process prompt and exit)
+- Tool control: `--tools read,grep,ls`, `--no-tools` (read-only and safe modes)
+- Discovery control: `--no-session`, `--no-extensions`, `--no-skills`, `--no-themes`
+- Explicit loading: `-e extensions/custom.ts`, `--skill ./my-skill/`
+- Model selection: `--model provider/id`, `--models` for cycling, `--list-models`, `--thinking high`
+- Session management: `-c` (continue), `-r` (resume picker), `--session <name>`
+- Content injection: `@file.md` syntax, `--system-prompt`, `--append-system-prompt`
+- Package management subcommands: `pi install`, `pi remove`, `pi update`, `pi list`, `pi config`
+- Exporting: `pi --export session.jsonl output.html`
+- Environment variables: PI_CODING_AGENT_DIR, API keys (ANTHROPIC_API_KEY, GEMINI_API_KEY, etc.)
+
+## CRITICAL: First Action
+
+Before answering ANY question, you MUST run the `pi --help` command to fetch the absolute latest flag definitions:
+```bash
+pi --help > /tmp/pi-cli-help.txt 2>&1 && cat /tmp/pi-cli-help.txt
+```
+
+Also check the main README for CLI examples:
+```bash
+firecrawl scrape "https://raw.githubusercontent.com/badlogic/pi-mono/refs/heads/main/packages/coding-agent/README.md" -o .firecrawl/pi-readme-cli.md --only-main-content
+```
+
+Then read these files to have the freshest reference.
+
+## How to Respond
+
+- Provide complete, working bash commands
+- Highlight security flags when discussing programmatic usage (`--no-session`, `--mode json`, `--tools`)
+- Explain how specific flags interact (e.g. `--print` with `--mode json`)
+- Use proper escaping for complex prompts
+- Prefer short flags (`-p`, `-c`, `-e`) for readability when appropriate

--- a/.pi/agents/pi-pi/config-expert.md
+++ b/.pi/agents/pi-pi/config-expert.md
@@ -1,0 +1,67 @@
+---
+description: >
+  Pi configuration expert — knows settings.json, providers, models, packages,
+  keybindings, and all configuration options.
+tools: read, grep, find, ls, bash, write, edit
+thinking: low
+max_turns: 20
+---
+
+You are a configuration expert for the Pi coding agent. You know EVERYTHING about Pi's settings, providers, models, packages, and keybindings.
+
+## Your Expertise
+
+### Settings (settings.json)
+
+- Locations: `~/.pi/agent/settings.json` (global), `.pi/settings.json` (project)
+- Project overrides global with nested merging
+- Model & Thinking: defaultProvider, defaultModel, defaultThinkingLevel, hideThinkingBlock, thinkingBudgets
+- UI & Display: theme, quietStartup, collapseChangelog, doubleEscapeAction, editorPaddingX, autocompleteMaxVisible, showHardwareCursor
+- Compaction: compaction.enabled, compaction.reserveTokens, compaction.keepRecentTokens
+- Retry: retry.enabled, retry.maxRetries, retry.baseDelayMs, retry.maxDelayMs
+- Message Delivery: steeringMode, followUpMode, transport (sse/websocket/auto)
+- Terminal & Images: terminal.showImages, terminal.clearOnShrink, images.autoResize, images.blockImages
+- Shell: shellPath, shellCommandPrefix
+- Model Cycling: enabledModels (patterns for Ctrl+P)
+- Markdown: markdown.codeBlockIndent
+- Resources: packages, extensions, skills, prompts, themes, enableSkillCommands
+
+### Providers & Models
+
+- Built-in providers: Anthropic, OpenAI, Google, Amazon, Groq, Mistral, OpenRouter, etc.
+- Custom models via `~/.pi/agent/models.json`
+- Custom providers via extensions (`pi.registerProvider`)
+- API key environment variables per provider
+- Model cycling with enabledModels patterns
+
+### Packages
+
+- Install: `pi install npm:pkg`, `git:repo`, `/local/path`
+- Manage: `pi remove`, `pi list`, `pi update`
+- package.json pi manifest: extensions, skills, prompts, themes
+- Convention directories: extensions/, skills/, prompts/, themes/
+- Package filtering with object form in settings
+- Scope: global (-g default) vs project (-l)
+
+### Keybindings
+
+- `~/.pi/agent/keybindings.json`
+- Customizable keyboard shortcuts
+
+## CRITICAL: First Action
+
+Before answering ANY question, you MUST fetch the latest Pi settings and providers documentation:
+```bash
+firecrawl scrape "https://raw.githubusercontent.com/badlogic/pi-mono/refs/heads/main/packages/coding-agent/docs/settings.md" -o .firecrawl/pi-settings-docs.md --only-main-content
+firecrawl scrape "https://raw.githubusercontent.com/badlogic/pi-mono/refs/heads/main/packages/coding-agent/docs/providers.md" -o .firecrawl/pi-providers-docs.md --only-main-content
+```
+
+Then read the fetched files. Also search the local codebase for existing settings files and configuration patterns.
+
+## How to Respond
+
+- Provide COMPLETE, VALID settings.json snippets
+- Show how project settings override global
+- Include environment variable setup for providers
+- Mention `/settings` command for interactive configuration
+- Warn about security implications of packages

--- a/.pi/agents/pi-pi/ext-expert.md
+++ b/.pi/agents/pi-pi/ext-expert.md
@@ -1,0 +1,53 @@
+---
+description: >
+  Pi extensions expert — knows how to build custom tools, event handlers, commands,
+  shortcuts, state management, custom rendering, and tool overrides.
+tools: read, grep, find, ls, bash, write, edit
+thinking: low
+max_turns: 25
+---
+
+You are an extensions expert for the Pi coding agent. You know EVERYTHING about building Pi extensions.
+
+## Your Expertise
+
+- Extension structure: default export function receiving ExtensionAPI
+- Custom tools via `pi.registerTool()` with TypeBox schemas
+- Event system: session_start, tool_call, tool_result, before_agent_start, context, agent_start/end, turn_start/end, message events, input, model_select
+- Commands via `pi.registerCommand()` with autocomplete
+- Shortcuts via `pi.registerShortcut()`
+- Flags via `pi.registerFlag()`
+- State management via tool result details and `pi.appendEntry()`
+- Custom rendering via renderCall/renderResult
+- Available imports: `@mariozechner/pi-coding-agent`, `@sinclair/typebox`, `@mariozechner/pi-ai` (StringEnum), `@mariozechner/pi-tui`
+- System prompt override via before_agent_start
+- Context manipulation via context event
+- Tool blocking and result modification
+- `pi.sendMessage()` and `pi.sendUserMessage()` for message injection
+- `pi.exec()` for shell commands
+- `pi.setActiveTools()` / `pi.getActiveTools()` / `pi.getAllTools()`
+- `pi.setModel()`, `pi.getThinkingLevel()`, `pi.setThinkingLevel()`
+- Extension locations: `~/.pi/agent/extensions/`, `.pi/extensions/`
+- Output truncation utilities
+
+## CRITICAL: First Action
+
+Before answering ANY question, you MUST fetch the latest Pi extensions documentation:
+```bash
+firecrawl scrape "https://raw.githubusercontent.com/badlogic/pi-mono/refs/heads/main/packages/coding-agent/docs/extensions.md" -o .firecrawl/pi-ext-docs.md --only-main-content
+```
+
+Then read the fetched file to have the freshest reference. Also search the local codebase for existing extension examples:
+```bash
+ls .pi/extensions/ 2>/dev/null
+find . -name "*.ts" -path "*/extensions/*" 2>/dev/null | head -20
+```
+
+## How to Respond
+
+- Provide COMPLETE, WORKING code snippets
+- Include all necessary imports
+- Reference specific API methods and their signatures
+- Show the exact TypeBox schema for tool parameters
+- Include renderCall/renderResult if the user needs custom tool UI
+- Mention gotchas (e.g., StringEnum for Google compatibility, tool registration at top level)

--- a/.pi/agents/pi-pi/keybinding-expert.md
+++ b/.pi/agents/pi-pi/keybinding-expert.md
@@ -1,0 +1,123 @@
+---
+description: >
+  Pi keyboard shortcut expert — knows registerShortcut(), Key IDs, modifier combos,
+  reserved keys, terminal compatibility (macOS/Kitty/legacy), and keybindings.json
+  customization.
+tools: read, grep, find, ls, bash, write, edit
+thinking: low
+max_turns: 20
+---
+
+You are a keyboard shortcut and keybinding expert for the Pi coding agent. You know EVERYTHING about registering extension shortcuts, key formats, reserved keys, terminal compatibility, and keybinding customization.
+
+## Your Expertise
+
+### registerShortcut() API
+
+- `pi.registerShortcut(keyId, { description, handler })` — registers a hotkey for the extension
+- Handler signature: `async (ctx: ExtensionContext) => void`
+- Always guard with `if (!ctx.hasUI) return;` at the top of the handler
+- Shortcuts are checked FIRST in input dispatch (before built-in keybindings)
+- If a shortcut conflicts with a reserved built-in, it is **silently skipped** — no error shown unless `--verbose`
+
+### Key ID Format
+
+Format: `[modifier+[modifier+]]key` (lowercase, order of modifiers doesn't matter)
+
+**Modifiers:** `ctrl`, `shift`, `alt`
+
+**Base keys:**
+- Letters: `a` through `z`
+- Special: `escape`/`esc`, `enter`/`return`, `tab`, `space`, `backspace`, `delete`, `insert`, `clear`, `home`, `end`, `pageUp`, `pageDown`, `up`, `down`, `left`, `right`
+- Function: `f1` through `f12`
+- Symbols: `` ` ``, `-`, `=`, `[`, `]`, `\`, `;`, `'`, `,`, `.`, `/`, `!`, `@`, `#`, `$`, `%`, `^`, `&`, `*`, `(`, `)`, `_`, `+`, `|`, `~`, `{`, `}`, `:`, `<`, `>`, `?`
+
+**Modifier combos:** `ctrl+x`, `shift+x`, `alt+x`, `ctrl+shift+x`, `ctrl+alt+x`, `shift+alt+x`, `ctrl+shift+alt+x`
+
+### Reserved Keys (CANNOT be overridden by extensions)
+
+These are in `RESERVED_ACTIONS_FOR_EXTENSION_CONFLICTS` and will be silently skipped:
+
+| Key | Action |
+| -------------- | ---------------------- |
+| `escape` | interrupt |
+| `ctrl+c` | clear / copy |
+| `ctrl+d` | exit |
+| `ctrl+z` | suspend |
+| `shift+tab` | cycleThinkingLevel |
+| `ctrl+p` | cycleModelForward |
+| `ctrl+shift+p` | cycleModelBackward |
+| `ctrl+l` | selectModel |
+| `ctrl+o` | expandTools |
+| `ctrl+t` | toggleThinking |
+| `ctrl+g` | externalEditor |
+| `alt+enter` | followUp |
+| `enter` | submit / selectConfirm |
+| `ctrl+k` | deleteToLineEnd |
+
+### Safe Keys for Extensions (FREE, no conflicts)
+
+**ctrl+letter (universally safe):**
+- `ctrl+x` — confirmed working
+- `ctrl+q` — may be intercepted by terminal XON/XOFF flow control
+- `ctrl+h` — alias for backspace in some terminals, use with caution
+
+**Function keys:** `f1` through `f12` — all unbound, universally compatible
+
+### macOS Terminal Compatibility
+
+This is CRITICAL for building extensions that work on macOS:
+
+| Combo | Legacy Terminal (Terminal.app, iTerm2) | Kitty Protocol (Kitty, Ghostty, WezTerm) |
+| ------------------- | ---------------------------------------------------- | ---------------------------------------- |
+| `ctrl+letter` | YES | YES |
+| `alt+letter` | NO — types special characters (ø, ∫, etc.) | YES |
+| `ctrl+alt+letter` | SOMETIMES — may conflict with macOS system shortcuts | YES |
+| `ctrl+shift+letter` | NO — needs Kitty protocol | YES |
+| `shift+alt+letter` | NO — needs Kitty protocol | YES |
+| Function keys | YES | YES |
+
+**Rule of thumb on macOS:** Use `ctrl+letter` (from the free list) or `f1`–`f12` for guaranteed compatibility. Avoid `alt+`, `ctrl+shift+`, and `ctrl+alt+` unless targeting Kitty-protocol terminals only.
+
+### Keybindings Customization (keybindings.json)
+
+- Location: `~/.pi/agent/keybindings.json`
+- Users can remap ANY action (including reserved ones) to different keys
+- Format: `{ "actionName": ["key1", "key2"] }`
+- When a reserved action is remapped away from a key, that key becomes available for extensions
+- The conflict check uses EFFECTIVE keybindings (after user remaps), not defaults
+
+### Key Helper (from @mariozechner/pi-tui)
+
+- `Key.ctrl("x")` → `"ctrl+x"`
+- `Key.shift("tab")` → `"shift+tab"`
+- `Key.alt("left")` → `"alt+left"`
+- `Key.ctrlShift("p")` → `"ctrl+shift+p"`
+- `Key.ctrlAlt("p")` → `"ctrl+alt+p"`
+- `matchesKey(data, keyId)` — test if input data matches a key ID
+
+### Debugging Shortcuts
+
+- Run with `pi --verbose` to see `[Extension issues]` section at startup
+- Shortcut conflicts show as warnings: "Extension shortcut 'X' conflicts with built-in shortcut. Skipping."
+- Extension shortcut errors appear as red text in the chat area
+- Shortcuts not matching in `matchesKey()` means the terminal isn't sending the expected escape sequence
+
+## CRITICAL: First Action
+
+Before answering ANY question, you MUST fetch the latest Pi keybindings documentation:
+```bash
+firecrawl scrape "https://raw.githubusercontent.com/badlogic/pi-mono/refs/heads/main/packages/coding-agent/docs/keybindings.md" -o .firecrawl/pi-keybindings-docs.md --only-main-content
+```
+
+Then read the fetched file. Search the local codebase for existing extensions that use registerShortcut().
+
+## How to Respond
+
+- ALWAYS check if the requested key combo is reserved before recommending it
+- ALWAYS warn about macOS compatibility issues with alt/shift combos
+- Provide COMPLETE registerShortcut() code with proper guard clauses
+- Include the Key helper import if using Key.ctrl() style
+- Recommend safe alternatives when a requested key is taken
+- Show how to debug with `--verbose` if shortcuts aren't firing
+- When suggesting keys, prefer this priority: free ctrl+letter > function keys > overridable non-reserved keys

--- a/.pi/agents/pi-pi/pi-orchestrator.md
+++ b/.pi/agents/pi-pi/pi-orchestrator.md
@@ -1,0 +1,103 @@
+---
+description: >
+  Primary meta-agent that coordinates pi-pi domain experts to research Pi docs in
+  parallel, then builds Pi components (extensions, themes, skills, settings, prompts,
+  agents, TUI components). The orchestrator dispatches experts via the Agent tool and
+  synthesizes findings into working implementations.
+tools: read, write, edit, bash, grep, find, ls, Agent
+thinking: medium
+max_turns: 30
+---
+
+You are **Pi Pi** — a meta-agent that builds Pi components. You create extensions, themes, skills, settings, prompt templates, agent definitions, and TUI components for the Pi coding agent.
+
+## Your Team
+
+You have a team of domain experts who research Pi documentation in parallel:
+
+| Expert | Agent | Specialty |
+|--------|-------|-----------|
+| Agent Expert | `pi-pi/agent-expert` | Agent definitions, pi-subagents format, discovery |
+| CLI Expert | `pi-pi/cli-expert` | CLI flags, env vars, subcommands, output modes |
+| Config Expert | `pi-pi/config-expert` | settings.json, providers, models, packages |
+| Ext Expert | `pi-pi/ext-expert` | Extensions, custom tools, events, rendering |
+| Keybinding Expert | `pi-pi/keybinding-expert` | Shortcuts, key combos, terminal compatibility |
+| Prompt Expert | `pi-pi/prompt-expert` | Prompt templates, argument substitution |
+| Skill Expert | `pi-pi/skill-expert` | SKILL.md format, directory structure, validation |
+| Theme Expert | `pi-pi/theme-expert` | Color tokens, vars system, theme JSON |
+| TUI Expert | `pi-pi/tui-expert` | TUI components, rendering, keyboard input |
+
+## How You Work
+
+### Phase 1: Research (PARALLEL)
+
+When given a build request:
+
+1. Identify which domains are relevant to the task.
+2. Dispatch relevant experts IN PARALLEL using the `Agent` tool with `run_in_background: true`.
+3. Ask each expert a SPECIFIC question — e.g., "How do I register a custom tool with renderCall in a Pi extension?" not "Tell me about extensions."
+4. Wait for ALL agents to complete. Use `get_subagent_result` to collect their findings.
+5. Synthesize the combined research into an implementation plan.
+
+### Phase 2: Build
+
+Once you have research from all experts:
+
+1. Synthesize findings into a coherent implementation plan.
+2. WRITE the actual files using your code tools (read, write, edit, bash, grep, find, ls).
+3. Create complete, working implementations — no stubs or TODOs.
+4. Follow existing patterns found in the codebase.
+5. Test where possible (e.g., validate JSON, check file structure).
+
+### Phase 3: Verify
+
+1. Ensure all created files follow Pi conventions.
+2. Validate JSON files are well-formed.
+3. Check that imports reference real packages.
+4. Confirm directory structure matches Pi's discovery rules.
+
+## Rules
+
+1. **ALWAYS query experts FIRST** before writing any Pi-specific code. You need fresh documentation.
+2. **Dispatch experts IN PARALLEL** — use `run_in_background: true` on all Agent calls, then collect results.
+3. **Be specific** in your questions — mention the exact feature, API method, or component you need.
+4. **You write the code** — experts only research. They cannot modify files.
+5. **Follow Pi conventions** — use TypeBox for schemas, StringEnum for Google compat, proper imports.
+6. **Create complete files** — every extension must have proper imports, type annotations, and all features.
+7. **Include a justfile entry** if creating a new extension (format: `pi -e extensions/<name>.ts`).
+
+## What You Can Build
+
+- **Extensions** (.ts files) — custom tools, event hooks, commands, UI components
+- **Themes** (.json files) — color schemes with all 51 tokens
+- **Skills** (SKILL.md directories) — capability packages with scripts
+- **Settings** (settings.json) — configuration files
+- **Prompt Templates** (.md files) — reusable prompts with arguments
+- **Agent Definitions** (.md files) — agent personas with frontmatter
+- **TUI Components** — interactive terminal UI elements
+
+## File Locations
+
+- Extensions: `extensions/` or `.pi/extensions/`
+- Themes: `.pi/themes/`
+- Skills: `.pi/skills/`
+- Settings: `.pi/settings.json`
+- Prompts: `.pi/prompts/`
+- Agents: `.pi/agents/` (discovered by @tintinweb/pi-subagents)
+
+## Expert Dispatch Examples
+
+To research extension tool registration and TUI rendering in parallel:
+
+```
+Agent: pi-pi/ext-expert
+Prompt: "How do I register a custom tool with TypeBox schema and renderCall/renderResult in a Pi extension? Show the complete pattern including imports."
+
+Agent: pi-pi/tui-expert  
+Prompt: "How do I create a custom TUI component with SelectList and DynamicBorder? Show complete code with imports and the ctx.ui.custom() wrapper."
+
+Agent: pi-pi/keybinding-expert
+Prompt: "What ctrl+letter shortcuts are safe for extensions on macOS? I need to register a shortcut for my custom tool."
+```
+
+Then collect all results, synthesize, and build.

--- a/.pi/agents/pi-pi/prompt-expert.md
+++ b/.pi/agents/pi-pi/prompt-expert.md
@@ -1,0 +1,83 @@
+---
+description: >
+  Pi prompt templates expert — knows the single-file .md format, frontmatter,
+  positional arguments ($1, $@, ${@:N}), discovery locations, and /template invocation.
+tools: read, grep, find, ls, bash, write, edit
+thinking: low
+max_turns: 15
+---
+
+You are a prompt templates expert for the Pi coding agent. You know EVERYTHING about creating Pi prompt templates.
+
+## Your Expertise
+
+- Prompt templates are single Markdown files that expand into full prompts
+- Filename becomes the command: `review.md` → `/review`
+- Simple, lightweight — one file per template, no directories or scripts needed
+
+### Format
+
+```markdown
+---
+description: What this template does
+---
+Your prompt content here with $1 and $@ arguments
+```
+
+### Arguments
+
+- `$1`, `$2`, ... — positional arguments
+- `$@` or `$ARGUMENTS` — all arguments joined
+- `${@:N}` — args from Nth position (1-indexed)
+- `${@:N:L}` — L args starting at position N
+
+### Locations
+
+- Global: `~/.pi/agent/prompts/*.md`
+- Project: `.pi/prompts/*.md`
+- Packages: `prompts/` directories or `pi.prompts` entries in package.json
+- Settings: `prompts` array with files or directories
+- CLI: `--prompt-template <path>` (repeatable)
+
+### Discovery
+
+- Non-recursive — only direct .md files in prompts/ root
+- For subdirectories, add explicitly via settings or package manifest
+
+### Key Differences from Skills
+
+- Single file (no directory structure needed)
+- No scripts, no setup, no references
+- Just markdown with optional argument substitution
+- Lightweight reusable prompts, not capability packages
+
+### Usage
+
+```
+/review              # Expands review.md
+/component Button    # Expands with argument
+/component Button "click handler"  # Multiple arguments
+```
+
+### Description
+
+- Optional frontmatter field
+- If missing, first non-empty line is used as description
+- Shown in autocomplete when typing `/`
+
+## CRITICAL: First Action
+
+Before answering ANY question, you MUST fetch the latest Pi prompt templates documentation:
+```bash
+firecrawl scrape "https://raw.githubusercontent.com/badlogic/pi-mono/refs/heads/main/packages/coding-agent/docs/prompt-templates.md" -o .firecrawl/pi-prompt-docs.md --only-main-content
+```
+
+Then read the fetched file. Also search the local codebase (.pi/prompts/) for existing prompt template examples.
+
+## How to Respond
+
+- Provide COMPLETE .md files with proper frontmatter
+- Include argument placeholders where appropriate
+- Write specific, actionable descriptions
+- Keep templates focused — one purpose per file
+- Show the filename and the /command it creates

--- a/.pi/agents/pi-pi/skill-expert.md
+++ b/.pi/agents/pi-pi/skill-expert.md
@@ -1,0 +1,52 @@
+---
+description: >
+  Pi skills expert — knows SKILL.md format, frontmatter fields, directory structure,
+  validation rules, and skill command registration.
+tools: read, grep, find, ls, bash, write, edit
+thinking: low
+max_turns: 20
+---
+
+You are a skills expert for the Pi coding agent. You know EVERYTHING about creating Pi skills.
+
+## Your Expertise
+
+- Skills are self-contained capability packages loaded on-demand
+- SKILL.md format with YAML frontmatter + markdown body
+- Frontmatter fields:
+  - name (required): max 64 chars, lowercase a-z, 0-9, hyphens, must match parent directory
+  - description (required): max 1024 chars, determines when agent loads the skill
+  - license (optional)
+  - compatibility (optional): max 500 chars
+  - metadata (optional): arbitrary key-value
+  - allowed-tools (optional): space-delimited pre-approved tools
+  - disable-model-invocation (optional): hide from system prompt, require /skill:name
+- Directory structure: `my-skill/SKILL.md` + scripts/ + references/ + assets/
+- Skill locations: `~/.pi/agent/skills/`, `.pi/skills/`, packages, settings.json
+- Discovery: direct .md files in root, recursive SKILL.md under subdirs
+- Skill commands: `/skill:name` with arguments
+- Validation: name matching, character limits, missing description = not loaded
+- Agent Skills standard (agentskills.io)
+- Using skills from other harnesses (Claude Code, Codex)
+- Progressive disclosure: only descriptions in system prompt, full content loaded on-demand
+
+## CRITICAL: First Action
+
+Before answering ANY question, you MUST fetch the latest Pi skills documentation:
+```bash
+firecrawl scrape "https://raw.githubusercontent.com/badlogic/pi-mono/refs/heads/main/packages/coding-agent/docs/skills.md" -o .firecrawl/pi-skill-docs.md --only-main-content
+```
+
+Then read the fetched file. Also search the local codebase for existing skill examples:
+```bash
+ls .pi/skills/ 2>/dev/null
+find .pi/skills -name "SKILL.md" 2>/dev/null | head -20
+```
+
+## How to Respond
+
+- Provide COMPLETE SKILL.md with valid frontmatter
+- Include setup scripts if dependencies are needed
+- Show proper directory structure
+- Write specific, trigger-worthy descriptions
+- Include helper scripts and reference docs as needed

--- a/.pi/agents/pi-pi/theme-expert.md
+++ b/.pi/agents/pi-pi/theme-expert.md
@@ -1,0 +1,46 @@
+---
+description: >
+  Pi themes expert — knows the JSON format, all 51 color tokens, vars system,
+  hex/256-color values, hot reload, and theme distribution.
+tools: read, grep, find, ls, bash, write, edit
+thinking: low
+max_turns: 20
+---
+
+You are a themes expert for the Pi coding agent. You know EVERYTHING about creating and distributing Pi themes.
+
+## Your Expertise
+
+- Theme JSON format with $schema, name, vars, colors sections
+- All 51 required color tokens across 7 categories:
+  - Core UI (11): accent, border, borderAccent, borderMuted, success, error, warning, muted, dim, text, thinkingText
+  - Backgrounds & Content (11): selectedBg, userMessageBg, userMessageText, customMessageBg, customMessageText, customMessageLabel, toolPendingBg, toolSuccessBg, toolErrorBg, toolTitle, toolOutput
+  - Markdown (10): mdHeading, mdLink, mdLinkUrl, mdCode, mdCodeBlock, mdCodeBlockBorder, mdQuote, mdQuoteBorder, mdHr, mdListBullet
+  - Tool Diffs (3): toolDiffAdded, toolDiffRemoved, toolDiffContext
+  - Syntax Highlighting (9): syntaxComment, syntaxKeyword, syntaxFunction, syntaxVariable, syntaxString, syntaxNumber, syntaxType, syntaxOperator, syntaxPunctuation
+  - Thinking Borders (6): thinkingOff, thinkingMinimal, thinkingLow, thinkingMedium, thinkingHigh, thinkingXhigh
+  - Bash Mode (1): bashMode
+- Optional HTML export section (pageBg, cardBg, infoBg)
+- Color value formats: hex (#ff0000), 256-color index (0-255), variable reference, empty string for default
+- vars system for reusable color definitions
+- Theme locations: `~/.pi/agent/themes/`, `.pi/themes/`
+- Hot reload when editing active custom theme
+- Selection via /settings or settings.json
+- $schema URL for editor validation
+
+## CRITICAL: First Action
+
+Before answering ANY question, you MUST fetch the latest Pi themes documentation:
+```bash
+firecrawl scrape "https://raw.githubusercontent.com/badlogic/pi-mono/refs/heads/main/packages/coding-agent/docs/themes.md" -o .firecrawl/pi-theme-docs.md --only-main-content
+```
+
+Then read the fetched file. Also search the local codebase (.pi/themes/) for existing theme examples.
+
+## How to Respond
+
+- Provide COMPLETE theme JSON with ALL 51 color tokens (no partial themes)
+- Use vars for palette consistency
+- Include the $schema for validation
+- Suggest color harmonies based on the user's aesthetic preference
+- Mention hot reload and testing tips

--- a/.pi/agents/pi-pi/tui-expert.md
+++ b/.pi/agents/pi-pi/tui-expert.md
@@ -1,0 +1,100 @@
+---
+description: >
+  Pi TUI expert — knows all built-in components (Text, Box, Container, Markdown,
+  Image, SelectList, SettingsList, BorderedLoader), custom components, overlays,
+  keyboard input, widgets, footers, and custom editors.
+tools: read, grep, find, ls, bash, write, edit
+thinking: low
+max_turns: 25
+---
+
+You are a TUI (Terminal User Interface) expert for the Pi coding agent. You know EVERYTHING about building custom UI components and rendering.
+
+## Your Expertise
+
+### Component Interface
+
+- render(width: number): string[] — lines must not exceed width
+- handleInput?(data: string) — keyboard input when focused
+- wantsKeyRelease? — for Kitty protocol key release events
+- invalidate() — clear cached render state
+
+### Built-in Components (from @mariozechner/pi-tui)
+
+- Text: multi-line text with word wrapping, paddingX, paddingY, background function
+- Box: container with padding and background color
+- Container: groups children vertically, addChild/removeChild
+- Spacer: empty vertical space
+- Markdown: renders markdown with syntax highlighting
+- Image: renders images in supported terminals (Kitty, iTerm2, Ghostty, WezTerm)
+- SelectList: selection dialog with theme, onSelect/onCancel
+- SettingsList: toggle settings with theme
+
+### From @mariozechner/pi-coding-agent
+
+- DynamicBorder: border with color function — ALWAYS type the param: `(s: string) => theme.fg("accent", s)`
+- BorderedLoader: spinner with abort support
+- CustomEditor: base class for custom editors (vim mode, etc.)
+
+### Keyboard Input
+
+- matchesKey(data, Key.up/down/enter/escape/etc.)
+- Key modifiers: Key.ctrl("c"), Key.shift("tab"), Key.alt("left"), Key.ctrlShift("p")
+- String format: "enter", "ctrl+c", "shift+tab"
+
+### Width Utilities
+
+- visibleWidth(str) — display width ignoring ANSI codes
+- truncateToWidth(str, width, ellipsis?) — truncate with ellipsis
+- wrapTextWithAnsi(str, width) — word wrap preserving ANSI codes
+
+### UI Patterns (copy-paste ready)
+
+1. Selection Dialog: SelectList + DynamicBorder + ctx.ui.custom()
+2. Async with Cancel: BorderedLoader with signal
+3. Settings/Toggles: SettingsList + getSettingsListTheme()
+4. Status Indicator: ctx.ui.setStatus(key, styledText)
+5. Widgets: ctx.ui.setWidget(key, lines | factory, { placement })
+6. Custom Footer: ctx.ui.setFooter(factory)
+7. Custom Editor: extend CustomEditor, ctx.ui.setEditorComponent(factory)
+8. Overlays: ctx.ui.custom(component, { overlay: true, overlayOptions })
+
+### Focusable Interface (IME Support)
+
+- CURSOR_MARKER for hardware cursor positioning
+- Container propagation for embedded inputs
+
+### Theming in Components
+
+- theme.fg(color, text) for foreground
+- theme.bg(color, text) for background
+- theme.bold(text) for bold
+- Invalidation pattern: rebuild themed content in invalidate()
+- getMarkdownTheme() for Markdown components
+
+### Key Rules
+
+1. Always use theme from callback — not imported directly
+2. Always type DynamicBorder color param: `(s: string) =>`
+3. Call tui.requestRender() after state changes in handleInput
+4. Return `{ render, invalidate, handleInput }` for custom components
+5. Use Text with padding (0, 0) — Box handles padding
+6. Cache rendered output with cachedWidth/cachedLines pattern
+
+## CRITICAL: First Action
+
+Before answering ANY question, you MUST fetch the latest Pi TUI documentation:
+```bash
+firecrawl scrape "https://raw.githubusercontent.com/badlogic/pi-mono/refs/heads/main/packages/coding-agent/docs/tui.md" -o .firecrawl/pi-tui-docs.md --only-main-content
+```
+
+Then read the fetched file. Also search the local codebase for existing TUI component examples in extensions/.
+
+## How to Respond
+
+- Provide COMPLETE, WORKING component code
+- Include all imports from @mariozechner/pi-tui and @mariozechner/pi-coding-agent
+- Show the ctx.ui.custom() wrapper for interactive components
+- Handle invalidation properly for theme changes
+- Include keyboard input handling where relevant
+- Show both the component class and the registration/usage code

--- a/.pi/settings.json
+++ b/.pi/settings.json
@@ -1,3 +1,3 @@
 {
-	"packages": ["..", "npm:@posthog/pi", "npm:pi-lean-ctx", "npm:@tintinweb/pi-subagents", "npm:pi-smart-voice-notify"],
+	"packages": ["..", "npm:@posthog/pi", "npm:pi-lean-ctx", "npm:@tintinweb/pi-subagents", "npm:pi-smart-voice-notify"]
 }

--- a/vault/wiki/concepts/agent-harness-architecture.md
+++ b/vault/wiki/concepts/agent-harness-architecture.md
@@ -1,0 +1,67 @@
+---
+type: concept
+tags:
+  - harness
+  - architecture
+  - context-engineering
+  - safety
+related:
+  - "[[Agentic Orchestration Pipeline]]"
+  - "[[Context Engineering]]"
+  - "[[Safety Defense-in-Depth]]"
+  - "[[sources/martin-fowler-harness-engineering]]"
+  - "[[sources/opendev-arxiv-2603.05344v1]]"
+---
+
+# Agent Harness Architecture
+
+The harness is everything in an AI coding agent except the model itself: the runtime orchestration layer that wraps the reasoning loop and coordinates tool dispatch, context management, safety enforcement, and session persistence. Defined as: **Agent = Model + Harness**.
+
+## Two-Phase Model
+
+### Scaffolding (Pre-Runtime)
+Runs once before the first prompt. Assembles the agent:
+- System prompt compilation (conditional, priority-ordered sections)
+- Tool schema building (from registry, MCP discovery, subagent schemas)
+- Subagent registration and initialization
+
+### Harness (Runtime)
+Operates continuously during execution:
+- Tool dispatch with safety gating
+- Context lifecycle management (compaction, reminders, memory)
+- Approval workflows (Manual/Semi-Auto/Auto)
+- Session persistence and undo tracking
+
+## Feedforward + Feedback Model
+
+| Direction | Type | Examples |
+|-----------|------|----------|
+| **Feedforward (Guides)** | Steer before action | System prompts, AGENTS.md, Skills, coding conventions, architecture docs |
+| **Feedback (Sensors)** | Observe after action | Linters, tests, review agents, type checkers, structural analysis |
+
+Two execution modes:
+- **Computational**: Deterministic, fast — tests, linters, type checkers
+- **Inferential**: LLM-based, semantic — AI code reviews, "LLM as judge"
+
+## The Steering Loop
+
+Human developers iterate on the harness: whenever an issue occurs repeatedly, improve feedforward guides or feedback sensors. Agents can help build harness components (write tests, generate linter rules, create documentation).
+
+## Harness Layers (OpenDev Reference)
+
+1. **Prompt Composition**: Conditional sections sorted by priority, provider-specific variants, ${VAR} substitution, two-part caching
+2. **Context Engineering**: Staged compaction, event-driven reminders, dual-memory architecture, tool result optimization
+3. **Tool System**: Registry with handler categories, lazy MCP discovery, batch execution, 9-pass fuzzy edit matching
+4. **Safety System**: 5-layer defense-in-depth (prompt → schema → approval → validation → hooks)
+5. **Persistence**: Session storage, operation log/undo, configuration hierarchy, provider cache
+
+## Harness Templates
+
+For common topologies (CRUD APIs, event processors, dashboards), a harness template bundles guides + sensors as a reusable package. Teams select tech stacks partly based on available harnesses.
+
+## Relevance to Our Harness
+
+Our current harness architecture:
+- **Scaffolding**: `.pi/skills/` system, agent prompt engineering, wiki as knowledge base
+- **Runtime**: `lean-ctx` for tool routing, `Agent` for subagent spawning, `wiki-autoresearch` for research
+- **Gaps**: No safety defense-in-depth, no staged compaction, no event-driven reminders, no team dispatch, no sequential chaining

--- a/vault/wiki/concepts/agentic-orchestration-pipeline.md
+++ b/vault/wiki/concepts/agentic-orchestration-pipeline.md
@@ -1,0 +1,56 @@
+---
+type: concept
+tags:
+  - orchestration
+  - multi-agent
+  - pipeline
+  - agent-architecture
+related:
+  - "[[Agent Harness Architecture]]"
+  - "[[Multi-Agent Specialization]]"
+  - "[[sources/disler-pi-vs-claude-code]]"
+  - "[[sources/opendev-arxiv-2603.05344v1]]"
+---
+
+# Agentic Orchestration Pipeline
+
+A structured workflow where multiple specialized AI agents coordinate to complete complex software engineering tasks. The orchestrator decomposes work, routes to specialists, and assembles results.
+
+## Three Orchestration Patterns
+
+### 1. Subagent Delegation (Fan-out)
+A primary agent spawns isolated subagents for independent subtasks. Each subagent runs in its own context window with filtered tool access. Results are collected and synthesized by the primary agent.
+
+**Implementation**: Pi's `subagent-widget` extension (`/sub <task>`), OpenDev's `spawn_subagent` tool.
+
+**Best for**: Parallel exploration, isolated analysis, background tasks.
+
+### 2. Team Dispatch (Specialist Routing)
+A dispatcher agent reviews user requests and selects the most appropriate specialist from a predefined roster. Each specialist has a domain-specific system prompt and tool set.
+
+**Implementation**: Pi's `agent-team` extension, configured via `.pi/agents/teams.yaml`. The dispatcher uses a `dispatch_agent` tool.
+
+**Best for**: Work that benefits from domain expertise (frontend vs backend, planning vs execution).
+
+### 3. Sequential Chaining (Pipeline)
+Multiple agents execute in sequence where each step's output feeds into the next step's prompt. The `$INPUT` variable carries the previous step's output; `$ORIGINAL` always contains the initial user prompt.
+
+**Implementation**: Pi's `agent-chain` extension, defined in `.pi/agents/agent-chain.yaml` as a list of `steps` with `agent` and `prompt` fields.
+
+**Best for**: Multi-phase workflows (plan → build → review → fix → verify).
+
+## Design Principles
+
+1. **Schema-level isolation**: Subagents receive filtered tool schemas — they can't attempt actions they shouldn't perform. More robust than runtime permission checks.
+2. **Context isolation**: Each subagent runs with an independent conversation history. Only summaries return to the parent, preventing context pollution.
+3. **Explicit termination**: Subagents have clear stop conditions to prevent over-exploration.
+4. **Parallel execution**: Independent subagent calls auto-parallelize via thread pools.
+5. **Model specialization**: Different pipeline stages can use different models (e.g., Opus for planning, Sonnet for building, Haiku for reviewing).
+
+## Harness Implementation Path
+
+Our harness can adopt all three patterns as Pi extensions:
+1. Extend existing `Agent` tool with team dispatch via YAML config
+2. Add chain orchestration with `$INPUT` variable injection
+3. Implement context isolation per subagent (fresh conversation per spawn)
+4. Add progress dashboards (grid for teams, step tracker for chains)

--- a/vault/wiki/concepts/context-engineering.md
+++ b/vault/wiki/concepts/context-engineering.md
@@ -1,55 +1,62 @@
 ---
 type: concept
-status: developing
-created: 2026-05-02
-updated: 2026-05-03
-tags: [concept, context, harness]
+tags:
+  - context-engineering
+  - token-management
+  - compaction
+  - memory
 related:
-  - "[[Context Engine (AI Coding)]]"
-  - "[[agentic-harness-context-enforcement]]"
-  - "[[context-anxiety]]"
-  - "[[Context-Aware System Reminders]]"
-  - "[[progressive-disclosure-agents]]"
-  - "[[structured-compaction]]"
-sources:
-  - "[[Source: OpenDev — Building AI Coding Agents for the Terminal]]"
-  - "[[Source: OpenAI Harness Engineering — 0 Lines of Human Code]]"
-  - "[[anthropic2026-harness-design]]"
+  - "[[Agent Harness Architecture]]"
+  - "[[sources/opendev-arxiv-2603.05344v1]]"
+  - "[[sources/martin-fowler-harness-engineering]]"
 ---
 
 # Context Engineering
 
-The practice of designing and optimizing the context that an AI agent receives — what information, how structured, and when provided. Context quality > model intelligence (validated by Augment SWE-bench Pro results: same model, 6-point improvement with better context).
+The practice of managing an LLM's context window as a first-class engineering concern. Context is a finite, expensive resource consumed by system prompts, tool schemas, conversation history, and tool outputs. Effective context engineering determines how long an agent can operate before context overflow degrades performance.
 
-## First Principles
+## Core Principles
 
-### Context Is a Budget, Not a Buffer
-Every capability added to the system prompt, every tool result returned to the agent, competes for the same finite token budget. In practice, tool outputs (file contents, command results, search hits) consume **70-80% of context** in a typical session. Richer outputs improve per-turn accuracy but shorten session life. (Source: OpenDev)
+1. **Entropy reduction**: Each context element should reduce uncertainty about the desired output
+2. **Minimal sufficiency**: Include only what is necessary to avoid attention dilution
+3. **Semantic continuity**: Context should evolve coherently across turns, not be reconstructed from scratch
 
-### Progressive Disclosure
-Give agents **maps, not encyclopedias**. OpenAI's finding: a giant AGENTS.md file crowds out the task, rots instantly, and can't be mechanically verified. Instead: short AGENTS.md (~100 lines) as table of contents pointing to a structured `docs/` directory. (Source: OpenAI Harness Engineering)
+## Key Techniques
 
-### Adaptive Compaction, Not Emergency Compaction
-Graduated reduction stages (70%→99% thresholds) outperform binary emergency compaction. Cheaper strategies (masking, pruning) often reclaim enough space to avoid expensive LLM summarization. Mark tool outputs as "active → faded → archived" progressively. (Source: OpenDev)
+### Adaptive Context Compaction (ACC)
+Five graduated stages instead of a single emergency threshold:
+- **70%**: Warning — log pressure, track trends
+- **80%**: Observation Masking — replace old tool results with reference pointers (~15 tokens each)
+- **85%**: Fast Pruning — walk backward, replace oldest results with `[pruned]` markers
+- **90%**: Aggressive Masking — shrink preservation window to most recent outputs only
+- **99%**: Full Compaction — LLM-based summarization of middle portion, keep recent verbatim
 
-### System Reminders at Decision Points
-Instructions in the system prompt lose influence as conversations grow. After 30+ tool calls, agents silently stop following them. Inject short, targeted reminders at the exact point of decision using `role: user` messages. Cap frequency to prevent noise. (Source: OpenDev, [[Context-Aware System Reminders]])
+ACC reduces peak context consumption by ~54%, often eliminating the need for emergency compaction.
 
-### Calibrate from API-Reported Token Counts
-Providers inject invisible content (safety preambles, tool schemas, internal formatting). Local token estimates systematically underestimate actual usage. Always treat the API's reported `prompt_tokens` as ground truth. (Source: OpenDev)
+### Dual-Memory Architecture
+- **Episodic memory**: LLM summary of full history (strategic context). Regenerated from full history every 5 messages to prevent summary drift.
+- **Working memory**: Last 6 exchanges verbatim (operational detail).
 
-### Dual-Memory for Thinking Contexts
-When providing context to a thinking/reasoning model: separate compressed long-range context (episodic summary) from detailed short-range context (recent messages verbatim). Regenerate episodic summary from full history periodically, not incrementally — iterative summarization accumulates drift. (Source: OpenDev)
+### Event-Driven System Reminders
+Short, targeted messages injected at decision points (not upfront in system prompt). Use `role: user` for maximum recency. Governed by counter budgets to prevent noise.
 
-### Offload Large Outputs to Filesystem
-When a tool produces output exceeding a threshold, write full content to scratch file, return short preview + file reference. Transforms a context-consumption problem into a retrieval problem — retrieval costs one tool call, context consumption is paid on every subsequent LLM call. (Source: OpenDev)
+### Lazy Tool Discovery
+Only discovered/explicitly invoked MCP tool schemas consume context. Baseline overhead: <5% instead of 40%.
 
-### Context Resets vs Compaction
-Anthropic found that some models exhibit "context anxiety" — wrapping up prematurely when approaching context limit. Compaction alone insufficient for Sonnet 4.5. Context resets (clear window, new agent with structured handoff) required. Opus 4.6 largely eliminated this — model capability determines which strategy works. (Source: Anthropic Harness Design)
+### Tool Result Optimization
+Per-tool-type summarization (file reads → metadata, search → match counts, directory listings → item counts). Large outputs (>8,000 chars) offloaded to scratch files with previews.
+
+### Prompt Caching
+Split system prompt into stable (cacheable) and dynamic parts. Stable portion (~80-90%) receives `cache_control` header, yielding ~88% input cost reduction on cached tokens.
+
+## Calibration
+
+Always use the API's reported `prompt_tokens` as calibration anchor, not local estimates. Providers inject invisible content (safety preambles, tool serialization) that local counting misses.
 
 ## Relevance to Our Harness
-- Our AGENTS.md may be too monolithic — consider restructuring as index + progressive disclosure
-- We lack graduated compaction — current approach is binary emergency
-- We lack system reminders — instructions fade over long sessions
-- We lack dual-memory for planning phases
-- Token calibration should use API-reported counts, not local estimates
+
+- No staged compaction — we rely on session restarts when context fills
+- No event-driven reminders — our system prompt decays over long sessions
+- No dual-memory — thinking contexts share full history
+- Partial tool result optimization — `lean-ctx` compresses bash output
+- Lazy discovery pattern exists — `ctx_discover_tools` for lean-ctx

--- a/vault/wiki/concepts/five-root-cause-metrics-sentrux.md
+++ b/vault/wiki/concepts/five-root-cause-metrics-sentrux.md
@@ -1,0 +1,40 @@
+---
+type: concept
+title: "Five Root Cause Metrics (sentrux)"
+created: 2026-05-03
+tags:
+  - sentrux
+  - code-metrics
+  - graph-theory
+related:
+  - "[[Quality Signal (sentrux)]]"
+  - "[[sentrux]]"
+sources:
+  - "[[sentrux-docs-root-cause-metrics]]"
+---
+
+# Five Root Cause Metrics (sentrux)
+
+sentrux computes 5 independent metrics covering the complete structural properties of a directed attributed dependency graph:
+
+| # | Metric | Theory | Measures |
+|---|--------|--------|----------|
+| 1 | Modularity | Newman 2004 | Graph community detection — do files cluster into independent modules? |
+| 2 | Acyclicity | Martin 2003 | Circular dependency detection via Tarjan's SCC |
+| 3 | Depth | Lakos 1996 | Longest dependency chain length |
+| 4 | Equality | Gini 1912 | Even distribution of complexity (no god files) |
+| 5 | Redundancy | Kolmogorov 1963 | Dead/duplicate code |
+
+## Dimensional Completeness
+3 edge properties + 2 node properties = 5 total dimensions:
+- **Edge properties:** modularity (clustering), acyclicity (cycles), depth (chain length)
+- **Node properties:** equality (concentration), redundancy (unnecessary nodes)
+
+Adding more metrics would either overlap (entropy ≈ Gini) or measure runtime behavior outside static analysis.
+
+## Why These Five?
+- **Modularity replaces** coupling, cohesion, god file detection, hotspot detection — all symptoms of low Q
+- **Acyclicity is fundamental:** cycles make build order undefined and testing impossible
+- **Depth captures** change propagation risk — deep chains mean small changes ripple far
+- **Equality targets** god files — the #1 source of AI agent confusion
+- **Redundancy captures** dead code — expands AI agent's search space without contributing behavior

--- a/vault/wiki/concepts/multi-agent-specialization.md
+++ b/vault/wiki/concepts/multi-agent-specialization.md
@@ -1,0 +1,61 @@
+---
+type: concept
+tags:
+  - multi-agent
+  - specialization
+  - team-composition
+  - model-routing
+related:
+  - "[[Agentic Orchestration Pipeline]]"
+  - "[[Agent Harness Architecture]]"
+  - "[[sources/disler-pi-vs-claude-code]]"
+  - "[[sources/mindstudio-four-agent-types]]"
+---
+
+# Multi-Agent Specialization
+
+The practice of assigning different agents to different cognitive roles based on their specialized system prompts, tool sets, and underlying models. Specialization matters more than the raw capability ceiling of any single model.
+
+## Specialization Axes
+
+### By Role (What the agent does)
+- **Planner**: Explores codebase, analyzes patterns, produces structured plans. Read-only tools.
+- **Builder**: Implements code changes, writes files, runs commands. Full read-write tools.
+- **Reviewer**: Analyzes diffs, finds issues, suggests improvements. Read + analysis tools.
+- **Fixer**: Addresses review feedback, applies targeted fixes. Write tools.
+- **Gatekeeper**: Final verification, test execution, merge approval. Read + test tools.
+- **Narrator**: Produces human-readable summaries, PR descriptions, documentation.
+
+### By Model (Which LLM powers it)
+- **Opus/Strong models**: Planning, reviewing, complex reasoning (high quality, high cost)
+- **Sonnet/Mid models**: Building, fixing, standard coding tasks (balanced quality/cost)
+- **Haiku/Fast models**: Spec-checking, PR descriptions, summarization (low cost, fast)
+- **Task routing**: Different pipeline stages use different models optimized for that stage
+
+### By Tool Set (What capabilities it has)
+- **Read-only**: Code explorer, reviewer (cannot modify files)
+- **Read-write**: Builder, fixer (can create/edit files)
+- **Shell access**: Builder, fixer (can run commands)
+- **Web access**: Researcher, web-cloner (can fetch URLs)
+- **User interaction**: Ask-user agents (structured surveys)
+
+## Team Composition
+
+Teams defined in YAML config map domain names to agent rosters:
+```yaml
+frontend: [planner, builder, reviewer]
+backend: [architect, implementer, tester]
+security: [auditor, remediator]
+```
+
+The dispatcher (orchestrator) selects the most appropriate team and specialist based on the user's request.
+
+## Model-Agnostic Design
+
+Specialization should be model-agnostic: switching providers requires only configuration changes, not code changes. Agents should declare model preferences per role but gracefully degrade to defaults.
+
+## Key Insight
+
+> "Multi-model pipelines beat single-model agents for non-trivial work. Specialization matters more than the raw capability ceiling of any one model." — Hamza L. (4CO-OP contributor)
+
+The 4CO-OP project demonstrates this with 9 specialized agents across Claude Code and Codex: Planner, Builder, Spec Checker, Escalation, Reviewer, Fixer, Gatekeeper, PR Writer, Narrator. Each runs the model best at that specific job.

--- a/vault/wiki/concepts/quality-signal-sentrux.md
+++ b/vault/wiki/concepts/quality-signal-sentrux.md
@@ -1,0 +1,37 @@
+---
+type: concept
+title: "Quality Signal (sentrux)"
+created: 2026-05-03
+tags:
+  - sentrux
+  - code-quality
+  - metrics
+related:
+  - "[[Five Root Cause Metrics (sentrux)]]"
+  - "[[sentrux]]"
+sources:
+  - "[[sentrux-docs-quality-signal]]"
+  - "[[sentrux-docs-root-cause-metrics]]"
+---
+
+# Quality Signal (sentrux)
+
+A single continuous scalar score (0–10,000) computed as the geometric mean of 5 normalized root cause metrics:
+
+```
+quality_signal = (modularity × acyclicity × depth × equality × redundancy)^(1/5) × 10000
+```
+
+## Theoretical Basis
+The geometric mean is chosen via the Nash Social Welfare theorem (1950): it is the unique aggregation function satisfying Pareto optimality, symmetry, and independence of irrelevant alternatives.
+
+## Properties
+- **Ungameable:** No metric can be improved in isolation without genuine structural improvement. Adding useless edges decreases modularity. Removing files without restructuring doesn't affect modularity.
+- **Language-agnostic:** Uses graph-theoretic properties computed from tree-sitter parse trees. Works identically across 52 languages.
+- **Monotonic convergence:** Designed to improve monotonically under correct agent action — like gradient descent.
+
+## Why Not Letter Grades?
+Letter grades (A-F) collapse information. A codebase with D cyclicity but A in everything else gets the same overall grade as B across the board. Continuous score preserves resolution for incremental improvement tracking.
+
+## Normalization
+Each metric normalized to [0, 1] before aggregation, ensuring equal weight regardless of raw units.

--- a/vault/wiki/concepts/safety-defense-in-depth.md
+++ b/vault/wiki/concepts/safety-defense-in-depth.md
@@ -1,0 +1,83 @@
+---
+type: concept
+tags:
+  - safety
+  - security
+  - architecture
+  - agent-governance
+related:
+  - "[[Agent Harness Architecture]]"
+  - "[[sources/opendev-arxiv-2603.05344v1]]"
+  - "[[sources/disler-pi-vs-claude-code]]"
+---
+
+# Safety Defense-in-Depth
+
+A multi-layer safety architecture where each layer independently prevents a class of harm. No single bypass compromises the system. The key principle: make unsafe operations structurally impossible rather than relying on runtime permission checks that the agent can probe or argue against.
+
+## Five Safety Layers
+
+### Layer 1: Prompt-Level Guardrails
+System prompt encodes security policy, action safety rules, git workflow requirements, error recovery patterns. The first line of defense — guides model reasoning toward safe behavior.
+
+### Layer 2: Schema-Level Tool Restrictions
+Tools absent from the agent's schema cannot be invoked, argued about, or probed. This is more robust than runtime checks:
+- **Plan mode**: Only read-only tools in schema. Write tools don't exist from the model's perspective.
+- **Subagent filtering**: Each subagent receives only tools relevant to its role.
+- **MCP discovery gating**: External tools appear only after explicit search + selection.
+
+### Layer 3: Runtime Approval System
+Three autonomy levels:
+- **Manual**: Every tool call requires explicit approval
+- **Semi-Auto**: Read-only commands auto-approved; writes prompt for confirmation
+- **Auto**: All operations approved for trusted workflows
+
+Rule types evaluated in priority order:
+- **Danger**: Regex match with auto-deny (cannot be overridden). Default rules: `rm -rf /`, `rm -rf *`, `chmod 777`
+- **Pattern**: Regex match against command string
+- **Command**: Exact match
+- **Prefix**: Prefix match (e.g., `git` matches `git push`)
+
+### Layer 4: Tool-Level Validation
+Per-tool safety checks executed during tool handling:
+- **DANGEROUS_PATTERNS blocklist**: `rm -rf`, `sudo`, fork bombs, `curl|bash` pipes, `dd` to devices
+- **Stale-read detection**: Rejects edits if file was modified since last read
+- **Output truncation**: Caps at 30,000 chars with head-tail strategy
+- **Timeouts**: 60s idle timeout, 600s absolute timeout
+
+### Layer 5: Lifecycle Hooks
+External scripts register for lifecycle events (PreToolUse, PostToolUse, SessionStart, Stop). Hooks can:
+- **Block** (exit code 2): Prevent tool execution entirely
+- **Mutate**: Modify tool arguments before execution (e.g., inject `--dry-run`)
+- **Observe**: Async logging/auditing after execution
+
+## Key Safety Patterns
+
+### Schema Gating > Permission Checks
+Removing tools from the agent's schema eliminates the entire class of attack — the model cannot reason about capabilities it doesn't know exist. Runtime permission checks let the agent argue for exceptions.
+
+### Approval Persistence
+Approval rules persist to disk across sessions. Without persistence, users re-approve same operations every session, leading to approval fatigue and blanket auto-approval.
+
+### Doom-Loop Detection
+MD5 fingerprint of `(tool_name, tool_args)` tracked in sliding window of 20 calls. Same fingerprint appearing 3+ times triggers warning → approval pause escalation.
+
+### Resource Bounding
+Every resource that grows with session length must have a cap: iteration limits, nudge budgets, undo history (50 ops), concurrent tool calls (5 max).
+
+## Pi's Damage Control Extension
+
+disler's `damage-control` extension maps to Layers 3-4:
+- **Dangerous Commands**: Regex patterns with `ask: true` or strict block
+- **Zero Access Paths**: `.env`, `~/.ssh/`, `*.pem`
+- **Read-Only Paths**: `package-lock.json`, `/etc/`
+- **No-Delete Paths**: `.git/`, `Dockerfile`, `README.md`
+
+## Relevance to Our Harness
+
+Current state: No safety defense-in-depth. We need:
+- Schema-level filtering for subagents (already have `allowed-tools` concept)
+- Runtime approval system for dangerous commands
+- DANGEROUS_PATTERNS blocklist
+- Stale-read detection for file edits
+- Doom-loop detection for repeated tool calls

--- a/vault/wiki/concepts/sentrux-mcp-integration.md
+++ b/vault/wiki/concepts/sentrux-mcp-integration.md
@@ -1,0 +1,36 @@
+---
+type: concept
+title: "sentrux MCP Integration"
+created: 2026-05-03
+tags:
+  - sentrux
+  - mcp
+  - ai-agents
+related:
+  - "[[sentrux]]"
+  - "[[Quality Signal (sentrux)]]"
+sources:
+  - "[[sentrux-github-repo]]"
+---
+
+# sentrux MCP Integration
+
+sentrux runs as a Model Context Protocol (MCP) server, giving AI coding agents real-time access to architectural health data.
+
+## Setup
+- **Claude Code:** `/plugin marketplace add sentrux/sentrux` then `/plugin install sentrux`
+- **Other clients (Cursor, Windsurf, OpenCode):** Add to MCP config: `{"command": "sentrux", "args": ["--mcp"]}`
+
+## Agent Workflow
+```
+scan("/project")       → quality_signal: 7342, files: 139, bottleneck: "modularity"
+session_start()        → Baseline saved
+... agent writes code ...
+session_end()          → pass: false, before: 7342, after: 6891
+```
+
+## Available Tools (9 total)
+`scan`, `health`, `session_start`, `session_end`, `rescan`, `check_rules`, `evolution`, `dsm`, `test_gaps`
+
+## Key Design
+The feedback loop closes automatically: sentrux provides the sensor (structural health), rules provide the spec (what "good" looks like), and the AI agent is the actuator (makes changes). No human intervention needed for routine quality checks.

--- a/vault/wiki/concepts/sentrux-rules-engine.md
+++ b/vault/wiki/concepts/sentrux-rules-engine.md
@@ -1,0 +1,49 @@
+---
+type: concept
+title: "sentrux Rules Engine"
+created: 2026-05-03
+tags:
+  - sentrux
+  - architecture-governance
+  - ci
+related:
+  - "[[sentrux]]"
+  - "[[sentrux MCP Integration]]"
+sources:
+  - "[[sentrux-docs-rules-engine]]"
+---
+
+# sentrux Rules Engine
+
+A TOML-based constraint system that defines and enforces architectural rules. Configured via `.sentrux/rules.toml` at the project root.
+
+## Capabilities
+- **Global constraints:** max cycles, max coupling grade, max cyclomatic complexity, god file detection
+- **Layer definitions:** ordered dependency hierarchy (lower order = more foundational)
+- **Boundary rules:** block specific dependency paths with human-readable reasons
+
+## Execution Modes
+1. **CLI:** `sentrux check .` — exit 0 (pass) or 1 (fail), CI-friendly
+2. **MCP:** Agent calls `check_rules()` — gets structured violation list, can self-correct before human sees
+
+## Example
+```toml
+[constraints]
+max_cycles = 0
+max_coupling = "B"
+max_cc = 25
+no_god_files = true
+
+[[layers]]
+name = "core"
+paths = ["src/core/*"]
+order = 0
+
+[[boundaries]]
+from = "src/app/*"
+to = "src/core/internal/*"
+reason = "App must not depend on core internals"
+```
+
+## Integration
+Works in CI (GitHub Actions), as pre-merge gate, and as MCP tool for AI agents. Agents receive structured violation data and can fix before committing.

--- a/vault/wiki/entities/disler-indydevdan.md
+++ b/vault/wiki/entities/disler-indydevdan.md
@@ -1,0 +1,33 @@
+---
+type: entity
+entity_type: person
+url: https://github.com/disler
+tags:
+  - pi-agent
+  - agentic-coding
+  - content-creator
+related:
+  - "[[Entity: Pi Coding Agent (pi-mono)]]"
+  - "[[sources/disler-pi-vs-claude-code]]"
+---
+
+# disler (IndyDevDan)
+
+GitHub: [disler](https://github.com/disler) | YouTube: [IndyDevDan](https://www.youtube.com/@indydevdan)
+
+Creator of the `pi-vs-claude-code` repository (928 stars) — the definitive showcase of Pi Coding Agent's extension capabilities. Author of 15+ Pi extensions covering multi-agent orchestration, safety auditing, UI customization, and cross-agent integration.
+
+## Contributions
+
+- **pi-vs-claude-code**: Collection of customized Pi instances demonstrating agentic coding patterns
+- **claude-code-hooks-mastery** (3K stars): Claude Code extension ecosystem reference
+- **Tactical Agentic Coding**: Educational content on agentic coding patterns
+- **YouTube channel**: Video walkthroughs of Pi extensions in action
+
+## Philosophy
+
+Focused on practical demonstrations of Pi's extensibility. The repo exists to answer "what does it look like to hedge against Claude Code" — showing that open-source agents can match or exceed closed-source alternatives through customization, not through matching feature-for-feature.
+
+## Relevance
+
+His extension patterns (subagent-widget, agent-team, agent-chain, damage-control) are the primary reference implementation for the orchestration pipeline we want to build. The extensions are clean, composable TypeScript — directly portable to our harness.

--- a/vault/wiki/entities/opendev.md
+++ b/vault/wiki/entities/opendev.md
@@ -1,0 +1,41 @@
+---
+type: entity
+entity_type: project
+url: https://github.com/opendev-to/opendev
+tags:
+  - coding-agent
+  - open-source
+  - terminal
+  - context-engineering
+related:
+  - "[[Entity: Pi Coding Agent (pi-mono)]]"
+  - "[[sources/opendev-arxiv-2603.05344v1]]"
+---
+
+# OpenDev
+
+Open-source, command-line AI coding agent by Nghi D. Q. Bui. First comprehensive technical report for a terminal-native interactive coding agent (arXiv:2603.05344v1, March 2026).
+
+## Architecture
+
+Four-layer system:
+1. **Entry & UI**: CLI, TUI (Textual), Web UI (FastAPI + WebSockets)
+2. **Agent**: MainAgent (single class, parameterized), Planner subagent, 8 specialized subagent types
+3. **Tool & Context**: 35 built-in tools across 12 handler categories, MCP integration, staged compaction
+4. **Persistence**: Session storage (JSON + JSONL), operation log/undo, configuration hierarchy, provider cache
+
+## Key Features
+
+- **Compound AI system**: 5 model roles (action, thinking, critique, vision, compact)
+- **Extended ReAct loop**: Thinking phase → Action phase → Decision with doom-loop detection
+- **Adaptive Context Compaction**: 5 graduated stages (70%→80%→85%→90%→99%)
+- **Defense-in-depth safety**: 5 independent layers
+- **Dual-memory architecture**: Episodic + Working memory
+- **Event-driven reminders**: 24 templates, 8 event detectors
+- **9-pass fuzzy edit matching**: Absorbs LLM formatting imprecision
+- **LSP integration**: Semantic code analysis for 30+ languages
+- **Shadow git snapshots**: Per-step undo without interfering with user's git
+
+## Relevance
+
+OpenDev's architecture paper is the most comprehensive reference for building terminal coding agents. Its context engineering, safety, and orchestration patterns are directly applicable to our harness. The paper's "Lessons Learned" section (Section 3) provides transferable engineering principles validated through production use.

--- a/vault/wiki/entities/pi-coding-agent.md
+++ b/vault/wiki/entities/pi-coding-agent.md
@@ -1,0 +1,53 @@
+---
+type: entity
+entity_type: project
+url: https://github.com/badlogic/pi-mono
+tags:
+  - pi-agent
+  - coding-agent
+  - open-source
+  - terminal
+related:
+  - "[[Entity: disler (IndyDevDan)]]"
+  - "[[Entity: OpenDev]]"
+  - "[[sources/disler-pi-vs-claude-code]]"
+---
+
+# Pi Coding Agent (pi-mono)
+
+Open-source AI agent toolkit by Mario Zechner (libGDX creator). 11.3K GitHub stars.
+
+## Components
+
+- **Coding Agent CLI**: Terminal-native agentic coding assistant
+- **Unified LLM API**: Single interface across multiple providers
+- **TUI and Web UI libraries**: Terminal and browser interfaces
+- **Slack bot**: Agent accessible via chat
+- **vLLM pods**: Self-hosted model infrastructure
+
+## Key Differentiators
+
+- **<1000 token system prompt**: Fully customizable, minimal by design
+- **Model agnostic**: Supports OpenAI, Anthropic, Google, OpenRouter, and many others
+- **Extension system**: TypeScript SDK for customizing UI, adding tools, hooking events
+- **Event lifecycle**: 15+ events including session_start, tool_call, agent_start, turn_end, message_update
+- **Extension composability**: Multiple `-e` flags stack extensions
+
+## Extension API
+
+Extensions are TypeScript files that hook into Pi's event system:
+```typescript
+// Minimal extension pattern
+export default function(pi) {
+  pi.on('session_start', (ctx) => { /* ... */ });
+  pi.on('tool_call', (ctx) => { /* intercept/modify */ });
+}
+```
+
+Built-in tools available to extensions: `read`, `bash`, `edit`, `write`.
+
+## Architecture Relevance
+
+Pi's extension API is the foundation for building agentic orchestration pipelines. The event system provides hooks at every lifecycle stage. The tool interface enables custom tool creation. Extensions compose without modifying core code.
+
+Our harness sits on top of Pi's extension API — we implement orchestration, safety, and context engineering as extensions rather than core modifications.

--- a/vault/wiki/entities/sentrux.md
+++ b/vault/wiki/entities/sentrux.md
@@ -1,0 +1,54 @@
+---
+type: entity
+title: "sentrux (tool)"
+created: 2026-05-03
+tags:
+  - code-quality
+  - static-analysis
+  - rust
+  - developer-tools
+  - ai-coding
+related:
+  - "[[Quality Signal (sentrux)]]"
+  - "[[Five Root Cause Metrics (sentrux)]]"
+  - "[[sentrux Rules Engine]]"
+  - "[[sentrux MCP Integration]]"
+sources:
+  - "[[sentrux-github-repo]]"
+  - "[[sentrux-dev-landing]]"
+---
+
+# sentrux (tool)
+
+An open-source (MIT), real-time architectural sensor for AI-agent-written code. Built in Rust, single binary, no runtime dependencies.
+
+## Core Identity
+"The sensor that helps AI agents close the feedback loop. Recursive self-improvement of code quality."
+
+## Key Stats
+- **First release:** March 11, 2026
+- **Latest version:** v0.5.7 (March 18, 2026)
+- **GitHub:** 1.9k stars, 168 forks
+- **Codebase:** ~36K lines of Rust, 87.5% Rust
+- **Languages supported:** 52 (via tree-sitter plugins)
+- **License:** MIT (free), BSL (Pro source-available)
+- **Pricing:** Free / Pro $15/month / Team $40/month/seat
+
+## Creators
+- **yjing** (primary author, GitHub: sentrux)
+- Contributors: claude (likely AI-generated), v1b3coder, trevorsilence
+
+## Technology
+- Pure Rust, egui + wgpu for GUI rendering
+- tree-sitter for multi-language parsing
+- MCP (Model Context Protocol) for AI agent integration
+- Ed25519 for Pro license validation
+- Squarified treemap layout with spatial index for O(1) hit testing
+
+## Philosophy
+1. Human-in-the-loop is non-negotiable
+2. Verification is more valuable than generation
+3. Good systems make good outcomes inevitable
+
+## Critical Reception
+Mixed. Reddit launch (r/rust, March 2026) drew both praise for the concept (human-in-the-loop, feedback loop) and criticism for rapid development pace (17 releases in one day), "vibe-coded" appearance, and unclear practical value. The tool gave its own repo a "D" rating.

--- a/vault/wiki/hot.md
+++ b/vault/wiki/hot.md
@@ -1,7 +1,7 @@
 ---
 type: meta
 title: "Hot Cache"
-updated: 2026-05-03T16:07:00
+updated: 2026-05-03T21:45:00
 created: 2026-04-30
 tags: []
 status: active
@@ -10,7 +10,96 @@ status: active
 # Recent Context
 
 ## Last Updated
-2026-05-03. **Automating Software Engineering — Lovable, Bolt, Emergent, Rocket**: Universal multi-agent pattern, environment control as moat, context engineering as central constraint, 0 human-code product (Codex). See below. **Legendary Engineering Patterns** and **Skill-First Architecture** also active.
+2026-05-03. **pi-vs-claude-code agentic orchestration pipeline** research filed. **sentrux.dev integrated**, **Automating Software Engineering**, **Legendary Engineering Patterns**, and **Skill-First Architecture** also active.
+
+---
+
+## pi-vs-claude-code — Agentic Orchestration Pipeline for Our Harness (May 2026)
+
+### Key Finding
+**Pi's TypeScript extension system can implement full multi-agent orchestration — subagent delegation, team dispatch, and sequential chaining — entirely in user-space without core agent changes.** disler/pi-vs-claude-code (928 stars) provides production-grade reference implementations of all three patterns. Combined with OpenDev's comprehensive architecture paper (arXiv:2603.05344v1) and Martin Fowler's harness engineering framework, clear implementation paths emerge for our harness.
+
+### 7 Key Findings
+1. **Three orchestration patterns cover the design space** (Source: [[sources/disler-pi-vs-claude-code]]): Subagent delegation (`/sub`), team dispatch (`/team` via `teams.yaml`), sequential chaining (`/chain` via `agent-chain.yaml`). All implementable as `.pi/skills/` extensions.
+2. **Schema-level isolation > runtime permission checks** (Source: [[sources/opendev-arxiv-2603.05344v1]]): Removing tools from subagent schemas makes dangerous operations structurally impossible. The model cannot argue for capabilities it doesn't know exist.
+3. **Context engineering is a first-class concern** (Source: [[sources/opendev-arxiv-2603.05344v1]]): Staged compaction (5 thresholds), event-driven reminders (24 templates, `role: user` injection), dual-memory architecture. Our harness lacks all three.
+4. **Harness = Guides + Sensors + Steering Loop** (Source: [[sources/martin-fowler-harness-engineering]]): Feedforward guides steer before action; feedback sensors observe after. Human iterates on both.
+5. **Multi-model pipelines beat single-model agents** (Source: [[sources/mindstudio-four-agent-types]]): Different pipeline stages benefit from different models (Opus for planning, Sonnet for building, Haiku for reviewing).
+6. **Safety requires defense-in-depth** (Source: [[sources/opendev-arxiv-2603.05344v1]]): Five independent layers — prompt → schema → approval → validation → hooks. Our harness has none in structured form.
+7. **Agent types must match task architecture** (Source: [[sources/mindstudio-four-agent-types]]): Coding Harness, Dark Factory, Auto Research, Orchestration — each optimized for different work. Mismatch = failure.
+
+### Concepts Created (5)
+[[concepts/agentic-orchestration-pipeline]], [[concepts/agent-harness-architecture]], [[concepts/multi-agent-specialization]], [[concepts/context-engineering]], [[concepts/safety-defense-in-depth]]
+
+### Entities Created (3)
+[[entities/pi-coding-agent]], [[entities/disler-indydevdan]], [[entities/opendev]]
+
+### Sources (5)
+[[sources/disler-pi-vs-claude-code]], [[sources/opendev-arxiv-2603.05344v1]], [[sources/martin-fowler-harness-engineering]], [[sources/mindstudio-four-agent-types]], [[sources/anthropic-effective-harnesses]]
+
+### Synthesis
+[[questions/Research-pi-vs-claude-code-agentic-orchestration-pipeline]] — Full research: 7 findings, 1 contradiction, 6 open questions
+
+### Implementation Path
+1. Extend existing `Agent` tool with team dispatch via YAML config (`.pi/agents/teams.yaml`)
+2. Add chain orchestration with `$INPUT` variable injection (`.pi/agents/agent-chain.yaml`)
+3. Implement context isolation per subagent (fresh conversation per spawn)
+4. Add progress dashboards (grid for teams, step tracker for chains)
+5. Build safety defense-in-depth (schema gating → approval → validation → hooks)
+6. Implement staged compaction (5 thresholds) and event-driven reminders
+
+### Open Questions
+- Event-driven system reminders in Pi's extension API?
+- Right compaction strategy for our context window?
+- Persistent approval rules across sessions?
+- 9-pass fuzzy editing in Pi's `edit` tool?
+- Performance impact of context isolation per subagent?
+- Steering loop mechanism (human review → update guides/sensors)?
+
+---
+
+## sentrux.dev — Architectural Sensor for AI Coding Agents (May 2026)
+
+### Key Finding
+**sentrux closes the feedback loop for AI-agent-written code — a real-time architectural sensor that computes a single Quality Signal (0–10,000) from 5 independent graph-theoretic metrics, visualizes the codebase as an interactive treemap, and integrates with AI coding agents via MCP.** Built in Rust (MIT), 52 languages via tree-sitter. First released March 11, 2026 (v0.5.7 as of March 18). 1.9k GitHub stars, 168 forks. Pro tier ($15/month) via runtime dylib plugin with Ed25519 license keys.
+
+### 7 Key Findings
+1. **Unique positioning as the missing feedback loop**: sensor (sentrux) → signal → controller (AI agent) → actuator (code changes) → system (codebase) → loop. Classical cybernetics (Wiener 1948, Tsien 1954).
+2. **Mathematically grounded scoring**: Quality Signal = geometric mean of (modularity × acyclicity × depth × equality × redundancy)^(1/5) × 10000. Justified by Nash Social Welfare theorem (1950). Claims "ungameable by design."
+3. **5 metrics cover complete structural space**: 3 edge properties (modularity Newman 2004, acyclicity Martin 2003, depth Lakos 1996) + 2 node properties (equality Gini 1912, redundancy Kolmogorov 1963).
+4. **MCP-first AI agent integration**: 9 tools (scan, health, session_start, session_end, rescan, check_rules, evolution, dsm, test_gaps). Agent detects quality degradation per session.
+5. **Pro tier via runtime plugin**: Pro features ($15/mo) in separately downloaded dylib. Ed25519 license keys with offline validation. Per-user watermarking. Team tier at $40/month/seat.
+6. **Rapid development velocity**: Initial commit to v0.5.7 with Pro architecture in ~1 week. 318 commits, 37 releases.
+7. **52 languages via tree-sitter**: Zero language-specific Rust code. Adding language = plugin.toml + tags.scm only.
+
+### Contradictions
+- **Self-assessment gap**: sentrux gives own repo a "D" rating — problematic for credibility.
+- **Rapid release pace vs stability**: 17 releases in one day during launch. Reddit flagged as "vibe-coded."
+- **Conceptual strength vs practical utility**: Community split between praising feedback loop concept and questioning usefulness.
+
+### Sources (7)
+[[sentrux-github-repo]], [[sentrux-dev-landing]], [[sentrux-docs-quality-signal]], [[sentrux-docs-root-cause-metrics]], [[sentrux-docs-rules-engine]], [[sentrux-docs-pro-architecture]], Reddit r/rust launch post
+
+### Concepts Created (4)
+[[Quality Signal (sentrux)]], [[Five Root Cause Metrics (sentrux)]], [[sentrux Rules Engine]], [[sentrux MCP Integration]]
+
+### Entity Created
+[[sentrux (tool)]]
+
+### Synthesis
+[[Research: sentrux.dev]] — Full research: 7 findings, 4 contradictions, 6 open questions
+
+### Open Questions
+- Production adoption unknown (tool <2 months old)
+- No independent reviews beyond Reddit launch thread
+- Accuracy varies by tree-sitter grammar maturity
+- Scalability with large codebases unverified
+- Pro plugin security: runtime dylib loading risks
+- No benchmarking against SonarQube, CodeClimate, etc.
+
+---
+
+Previous (2026-05-03): **Automating Software Engineering**, **Legendary Engineering Patterns**, and **Skill-First Architecture** research also active. See below.
 
 ---
 

--- a/vault/wiki/index.md
+++ b/vault/wiki/index.md
@@ -15,8 +15,8 @@ This wiki maps the codebase architecture, tracks key software design decisions, 
 
 | Layer | Module | Summary |
 |-------|--------|---------|
-| — | [[harness]] | 8-layer mandatory pipeline with drift monitor + cross-cutting tool enhancements |
-| — | [[harness-implementation-plan]] | Master build plan (Skill-First v2): phases mapped to skills vs code, unified token budget, all research integrated |
+| — | [[harness]] | 8-layer mandatory pipeline with drift monitor + sentrux structural gate + cross-cutting tool enhancements |
+| — | [[harness-implementation-plan]] | Master build plan (Skill-First v2): phases mapped to skills vs code, unified token budget, sentrux P44 integration |
 | L1 | [[spec-hardening]] | Block execution until ambiguities resolved |
 | L2 | [[structured-planning]] | Machine-readable task DAG + sprint contracts |
 | L2.5 | [[drift-detection-unified]] | Runtime drift monitor: 3 paradigms (tool-call, spec, implementation) |
@@ -119,6 +119,16 @@ This wiki maps the codebase architecture, tracks key software design decisions, 
 | [[mcp-tool-routing]] | MCP protocol for semantic search as first-class agent tool |
 | [[codebase-to-context-ingestion]] | Converting entire codebases into structured LLM context |
 
+## Concepts — Orchestration & Harness
+
+| Concept | Summary |
+|---------|---------|
+| [[agentic-orchestration-pipeline]] | Three patterns: subagent delegation, team dispatch, sequential chaining |
+| [[agent-harness-architecture]] | Agent = Model + Harness. Scaffolding + Harness phases. Feedforward guides + Feedback sensors |
+| [[multi-agent-specialization]] | Specialization by role, model, and tool set. Team composition via YAML config |
+| [[context-engineering]] | Staged compaction, dual-memory, event-driven reminders, lazy tool discovery, prompt caching |
+| [[safety-defense-in-depth]] | Five-layer architecture: prompt → schema → approval → validation → hooks |
+
 ## Concepts — Agent Architecture
 
 | Concept | Summary |
@@ -161,7 +171,20 @@ This wiki maps the codebase architecture, tracks key software design decisions, 
 | [[extensions]] | Programmatic hooks |
 | [[bench]] | Evaluation tools (terminal-bench) |
 
-## Entities
+## Entities — Projects & Tools
+
+| Entity | Summary |
+|--------|---------|
+| [[pi-coding-agent]] | Open-source terminal coding agent by Mario Zechner. TypeScript extension API. Our harness platform |
+| [[opendev]] | Open-source terminal agent. First comprehensive architecture paper (arXiv:2603.05344v1) |
+
+## Entities — People
+
+| Entity | Summary |
+|--------|---------|
+| [[disler-indydevdan]] | Creator of pi-vs-claude-code. 15+ Pi extensions. Reference implementation for orchestration |
+
+## Entities — Companies
 
 | Entity | Summary |
 |--------|---------|
@@ -184,6 +207,15 @@ This wiki maps the codebase architecture, tracks key software design decisions, 
 | [[codesearch]] | Rust MCP server for Claude Code/OpenCode |
 | [[javascript-runtimes]] | Node.js (stable, mature), Deno (secure, tooling-rich), Bun (fast, drop-in replacement) |
 | [[vitest]] | Vite-native test framework, Jest-compatible, v4.1.5, Oxc-powered TypeScript |
+
+## Concepts — Code Quality & Architecture Governance
+
+| Concept | Summary |
+|---------|---------|
+| [[Quality Signal (sentrux)]] | Geometric mean of 5 root cause metrics (0-10,000 score), Nash Social Welfare theorem |
+| [[Five Root Cause Metrics (sentrux)]] | modularity, acyclicity, depth, equality, redundancy — 3 edge + 2 node graph properties |
+| [[sentrux Rules Engine]] | TOML-based architectural constraint system with layers, boundaries, CI enforcement |
+| [[sentrux MCP Integration]] | 9-tool MCP server for AI agent feedback loops: scan, session_start/end, check_rules, etc. |
 
 ## Concepts — TypeScript & Code Organization
 
@@ -209,6 +241,7 @@ This wiki maps the codebase architecture, tracks key software design decisions, 
 
 | Synthesis | Summary |
 |-----------|---------|
+| [[Research: pi-vs-claude-code Agentic Orchestration Pipeline]] | **NEW**: Three orchestration patterns, harness architecture, safety layers, implementation path |
 | [[Research: Augment Code Context Engine]] | Context Engine architecture, benchmarks, integration plan for harness |
 | [[Research: Model-Adaptive Agent Harness Design]] | Four-layer harness must be specialized per model |
 | [[Research: context-mode vs lean-ctx]] | context-mode vs lean-ctx + Think in Code enforcement |
@@ -239,6 +272,11 @@ This wiki maps the codebase architecture, tracks key software design decisions, 
 
 | Source | Type | Summary |
 |--------|------|---------|
+| [[sources/disler-pi-vs-claude-code]] | github-repo | Pi extension showcase: 15+ extensions for orchestration, safety, UI, cross-agent integration |
+| [[sources/opendev-arxiv-2603.05344v1]] | academic-paper | OpenDev architecture: compound AI system, ACC, system reminders, 5-layer safety (Mar 2026) |
+| [[sources/martin-fowler-harness-engineering]] | engineering-blog | Harness = Guides + Sensors + Steering Loop. Computational vs Inferential controls (Apr 2026) |
+| [[sources/mindstudio-four-agent-types]] | article | Four agent types: Coding Harness, Dark Factory, Auto Research, Orchestration (2026) |
+| [[sources/anthropic-effective-harnesses]] | engineering-blog | Authoritative harness definition: runtime framework for tool dispatch, context, safety (2025) |
 | [[Source: Lovable Architecture & Clone Analysis]] | blog | Multi-agent architecture: Planner→Architect→Coder, Pydantic-typed handoffs, LangGraph orchestration |
 | [[Source: Bolt.new Architecture & Case Study]] | case-study | WebContainers + Claude, 0→$4M ARR in 4 weeks, Remix frontend, open source |
 | [[Source: Rocket.new — Vibe Solutioning Platform]] | news | Strategy→Build→Intelligence platform, $15M seed, 1.5M users, "vibe McKinsey" |
@@ -328,6 +366,12 @@ This wiki maps the codebase architecture, tracks key software design decisions, 
 | [[Source: AgentBus Jinja2 Prompt Pipelines]] | engineering-blog | Jinja2 templating: inheritance, conditionals, loops, pipeline runner |
 | [[Source: TianPan Prompt Caching Architecture]] | engineering-blog | Multi-tier caching: semantic→prefix→full, 60-90% savings, cache boundary control |
 | [[Source: Arxiv — Don't Break the Cache]] | academic-paper | PwC evaluation: 41-80% cost reduction, system-prompt-only caching optimal |
+| [[sentrux-github-repo]] | github-repo | sentrux: 1.9k stars, 52 languages, MCP server, 5 metrics, MIT |
+| [[sentrux-dev-landing]] | website | sentrux.dev: landing page, cybernetic feedback loop, pricing |
+| [[sentrux-docs-quality-signal]] | documentation | Quality Signal formula, geometric mean justification, Nash theorem |
+| [[sentrux-docs-root-cause-metrics]] | documentation | 5 metrics mathematical definitions, graph-theoretic completeness |
+| [[sentrux-docs-rules-engine]] | documentation | .sentrux/rules.toml constraint system with layers and boundaries |
+| [[sentrux-docs-pro-architecture]] | documentation | Pro tier: runtime dylib, Ed25519 licenses, $15/mo, per-user watermarking |
 | [[ts-strict-mode-rishikc]] | article | TypeScript strict mode guide: 8+ sub-flags, migration strategy, ESLint pairing |
 | [[ts-runtimes-comparison-betterstack]] | article | Node.js vs Deno vs Bun: benchmarks, tooling, security, TS support (2026) |
 | [[barrel-files-tkdodo]] | article | Barrel files cause 68% module bloat, circular imports — stop using in app code |

--- a/vault/wiki/log.md
+++ b/vault/wiki/log.md
@@ -8,6 +8,25 @@ tags: [meta, log, operations]
 
 # Wiki Operations Log
 
+## [2026-05-03] wiki-autoresearch | pi-vs-claude-code Agentic Orchestration Pipeline
+- Rounds: 2 (repo scrape + 4 broad searches + 2 gap-fill searches)
+- Sources found: 5
+- Pages created: [[sources/disler-pi-vs-claude-code]], [[sources/opendev-arxiv-2603.05344v1]], [[sources/martin-fowler-harness-engineering]], [[sources/mindstudio-four-agent-types]], [[sources/anthropic-effective-harnesses]] (sources), [[concepts/agentic-orchestration-pipeline]], [[concepts/agent-harness-architecture]], [[concepts/multi-agent-specialization]], [[concepts/context-engineering]], [[concepts/safety-defense-in-depth]] (concepts), [[entities/pi-coding-agent]], [[entities/disler-indydevdan]], [[entities/opendev]] (entities), [[questions/Research-pi-vs-claude-code-agentic-orchestration-pipeline]] (synthesis)
+- Pages updated: [[index]], [[log]], [[hot]]
+- Key finding: Pi's extension system can implement full multi-agent orchestration (subagent delegation, team dispatch, sequential chaining) entirely in user-space TypeScript. Three orchestration patterns + five-layer safety architecture + staged context compaction. Schema-level tool isolation more robust than runtime permission checks. Harness = Guides + Sensors + Steering Loop. Our harness can adopt all three orchestration patterns as `.pi/skills/` extensions backed by YAML config.
+
+## [2026-05-03] harness-update | sentrux integration into harness implementation plan
+- Replaced Fallow (P44a-g) with sentrux for structural quality gate
+- Added sentrux MCP (9 tools) to L2.5 drift monitor, L3 grounding, P20 gate, L5 observability
+- Updated: [[harness-implementation-plan]], [[harness]], [[Research: sentrux.dev]], [[index]], [[hot]]
+- sentrux adds 0 LLM tokens — all tools are deterministic Rust computations
+
+## [2026-05-03] wiki-autoresearch | sentrux.dev
+- Rounds: 1 (primary source scrape + docs + 1 external search)
+- Sources found: 7 (GitHub README, sentrux.dev, 4 docs pages, Pro architecture doc, Reddit launch post)
+- Pages created: [[sentrux-github-repo]], [[sentrux-dev-landing]], [[sentrux-docs-quality-signal]], [[sentrux-docs-root-cause-metrics]], [[sentrux-docs-rules-engine]], [[sentrux-docs-pro-architecture]] (sources), [[Quality Signal (sentrux)]], [[Five Root Cause Metrics (sentrux)]], [[sentrux Rules Engine]], [[sentrux MCP Integration]] (concepts), [[sentrux (tool)]] (entity), [[Research: sentrux.dev]] (synthesis)
+- Key finding: sentrux positions itself as the missing feedback loop for AI-agent code quality — 5 graph-theoretic metrics aggregated via geometric mean (Nash theorem), MCP integration with 9 tools, 52 languages via tree-sitter. <2 months old, 1.9k stars, mixed community reception.
+
 ## [2026-05-03] autoresearch | Automating Software Engineering — Lovable, Bolt, Emergent, Rocket
 - Rounds: 1 (5 broad searches + 11 scrapes)
 - Sources found: 6 (Lovable architecture/clone/docs, Bolt architecture/EvilMartians, OpenAI Codex blog, OpenDev arxiv, Anthropic harness blog, Rocket platform + TechCrunch, Emergent website)

--- a/vault/wiki/modules/harness-implementation-plan.md
+++ b/vault/wiki/modules/harness-implementation-plan.md
@@ -34,6 +34,12 @@ sources:
   - "[[claude-code-architecture-vila-lab-2026]]"
   - "[[codeact-apple-2024]]"
   - "[[fallow-rs-codebase-intelligence]]"
+  - "[[sentrux-github-repo]]"
+  - "[[sentrux-docs-quality-signal]]"
+  - "[[sentrux-docs-root-cause-metrics]]"
+  - "[[sentrux-docs-rules-engine]]"
+  - "[[sentrux-docs-pro-architecture]]"
+  - "[[Research: sentrux.dev]]"
 ---
 
 # Harness Implementation Plan (Skill-First v2)
@@ -107,16 +113,18 @@ L1: harness-spec skill       →  Hardens specification, resolves ambiguity
 L2: harness-plan skill       →  Generates YAML task DAG with sprint contracts
   ↓
 L2.5: drift-monitor.ts code →  LLM-first drift detection every 8 turns (Haiku 4.5) + rule pre-filter
+        + sentrux MCP        →  Structural health baseline via session_start/end. Catches architectural decay.
   ↓
 L3: Agent Execution          →  Flat tools (P43 deferred). Drift monitor watches tool_result events.
+      + sentrux MCP          →  Agent can scan() for structural awareness, check_rules() before commits.
   ↓
 L4: harness-critic skill     →  Spawns critic agent via pi-subagents. iMAD gating. Consensus filing.
   ↓
-P20: harness-gate skill      →  Deterministic: biome + tsc + fallow. 0 LLM tokens.
+P20: harness-gate skill      →  Deterministic: biome + tsc + fallow (dead code) + sentrux check (architecture). 0 LLM tokens.
   ↓
-L5: harness-observe skill    →  Keep Rate tracking, LLM-as-Judge.
+L5: harness-observe skill    →  Keep Rate tracking, LLM-as-Judge, Quality Signal trending via sentrux evolution.
   ↓
-L6: harness-memory skill     →  Wiki read-first/write-after contract.
+L6: harness-memory skill     →  Wiki read-first/write-after contract. Structural baselines via sentrux gate.
   ↓
 L7: Schema Orchestration     →  Archon YAML workflow (already YAML-based, no code).
   ↓
@@ -184,7 +192,7 @@ Config: `.pi/harness/config.json` → `driftMonitor.*` keys.
 
 | Phase | What | Method | Files |
 |-------|------|--------|-------|
-| P20 | Final Lint + Format Gate | **SKILL** + BASH | `.pi/skills/harness-gate/SKILL.md` — instructions; bash runs biome/tsc/fallow |
+| P20 | Final Lint + Format + Architecture Gate | **SKILL** + BASH | `.pi/skills/harness-gate/SKILL.md` — instructions; bash runs biome/tsc/fallow/sentrux |
 | P21 | Automated Observability + Keep Rate | **SKILL** | `.pi/skills/harness-observe/SKILL.md` |
 | P22 | Persistent Memory (wiki vault) | **SKILL** | `.pi/skills/harness-memory/SKILL.md` |
 | P23 | Schema Orchestration (Archon DAG) | YAML | `.archon/workflows/*.yaml` (already YAML-based) |
@@ -198,7 +206,19 @@ Config: `.pi/harness/config.json` → `driftMonitor.*` keys.
 | P27 | Context Anxiety Guard | **SKILL** | Can be skill-based with drift monitor integration |
 | P28 | Positive Agent Loop Hooks | CODE | Extensions (hooks are deterministic) |
 | P29 | Per-Tool Per-Model Error Classification | **SKILL** | `harness-observe/reference.md` (analysis is LLM evaluation) |
-| P44a-g | Fallow Integration | Mixed | MCP config + `harness-gate/reference.md` instructions |
+### P44: Structural Quality Gate — sentrux Integration (replaces Fallow)
+
+sentrux fully replaces Fallow for all codebase intelligence functions. It provides everything Fallow did (dead code, duplication, complexity, boundaries) plus additional capabilities Fallow lacked: modularity analysis (Newman 2004), acyclicity detection (Tarjan's SCC), dependency depth (Lakos 1996), equality/god-file detection (Gini 1912), session baseline/diff, and MCP integration with 9 tools.
+
+| Phase | What | Method | Files |
+|-------|------|--------|-------|
+| P44a | sentrux MCP tool registration (9 tools) | CONFIG | `.pi/mcp/sentrux.json` — scan, health, session_start/end, rescan, check_rules, evolution, dsm, test_gaps |
+| P44b | Pre-verification structural gate (`sentrux check`) | BASH + SKILL | Invoked by harness-gate skill in P15b sandbox |
+| P44c | CI structural pass/fail (`sentrux check .` exits 0/1) | BASH | `.github/workflows/quality.yml` |
+| P44d | Quality Signal tracking in L5 observability | SKILL | `harness-observe/reference.md` — sentrux evolution for trending |
+| P44e | Rules engine enforcement (`.sentrux/rules.toml`) | CONFIG | Project-root `.sentrux/rules.toml` — layers, boundaries, constraints |
+| P44f | Structural baselines in L6 memory | BASH | `sentrux gate --save` before session, `sentrux gate .` after |
+| P44g | Session structural diff (catch degradation) | MCP | `session_start()` / `session_end()` via MCP — integrated into L2.5 drift monitor |
 
 ### Future Phases — Method TBD
 
@@ -223,16 +243,16 @@ Per subtask. Skill activation costs comparable to code module loading but with p
 |---------------|--------|-----------|
 | L1 Spec Hardening (skill) | ~2,500 | Skill activation ~2,000 + spec generation + Q&A |
 | L2 Planning (skill) | ~4,500 | Skill activation + plan generation + sprint contracts |
-| L2.5 Drift Monitor (code) | ~1,500-2,200 | Haiku 4.5 every 8 turns. Rule pre-filter: 0 tokens. |
-| Pre-Verification Sandbox (P15b) | ~0-200 | Deterministic compile/lint. LLM tokens only on failure. |
+| L2.5 Drift Monitor (code) | ~1,500-2,200 | Haiku 4.5 every 8 turns. Rule pre-filter: 0 tokens. sentrux session_start/end: 0 LLM tokens (MCP). |
+| Pre-Verification Sandbox (P15b) | ~0-200 | Deterministic compile/lint/sentrux check. LLM tokens only on failure. |
 | L4 Adversarial (skill + agent) | ~4,500 | Skill activation + critic sub-agent + selective debate |
-| Phase 16 Lint+Format Gate | ~0 | Deterministic bash. Skill provides instructions — 0 tokens for execution. |
-| L5 Observability (skill) | ~2,000 | Skill activation + metric analysis |
+| Phase 16 Lint+Format+Arch Gate | ~0 | Deterministic bash: biome + tsc + fallow + sentrux check. 0 LLM tokens. |
+| L5 Observability (skill) | ~2,000 | Skill activation + metric analysis. sentrux evolution: 0 LLM tokens (MCP data). |
 | L6 Memory Writes (skill) | ~1,000 | Skill activation + wiki interaction |
 | Browser Subagent (P30) | ~0-500 | Deterministic screenshot + pixel diff |
 | Artifact Generation (P31) | ~1,000 | Skill activation + artifact generation |
 | L7+L8 Orchestration + Query | ~1,000 | Wiki bootstrapping amortized |
-| **Total per subtask** | **~16,500-18,000** | Comparable to v1. Skill activation replaces code module loading. |
+| **Total per subtask** | **~16,500-18,000** | sentrux MCP tools add 0 LLM tokens — they are deterministic structural computations. |
 
 ### Savings from Skill-First Architecture
 
@@ -245,6 +265,7 @@ Per subtask. Skill activation costs comparable to code module loading but with p
 | AST truncation | 30-50% input tokens (unchanged) |
 | Fuzzy edit matching | 5-15% retry round elimination (unchanged) |
 | TS Execution Layer (P43, deferred) | 3-4x context reduction (unchanged) |
+| sentrux MCP structural checks | 0 LLM tokens for architecture gate — deterministic Rust computation. Replaces ~500-1,000 tokens of LLM-based structural review that Fallow required for interpretation. |
 
 ---
 
@@ -280,7 +301,8 @@ Unchanged from v1. Every debate verdict writes to `wiki/consensus/`. The harness
 | **Gitingest** (bulk ingestion) | P15 | Skill |
 | **pi-messenger** (stripped) | P17 | Code (transport layer — deterministic) |
 | **agent-browser** (Vercel Labs) | P30 | Bash CLI — invoked by skill |
-| **Fallow** (codebase intelligence) | P44 | MCP + bash — invoked by gate skill |
+| **sentrux** (structural quality gate) | P44 | MCP + Bash + Config — replaces Fallow. 9 MCP tools, rules engine, session diff. |
+| **Fallow** (dead code detection) | P20 gate | Bash — retained for dead code only (sentrux covers architecture). Complementary, not replaced. |
 
 ---
 
@@ -288,6 +310,7 @@ Unchanged from v1. Every debate verdict writes to `wiki/consensus/`. The harness
 
 All research from April-May 2026 remains valid. The skill-first architecture is independently validated by:
 
+- **sentrux — Structural Feedback Loop** (Mar 2026): Validates FP #2 (every pipeline layer reads wiki first), FP #4 (three quality concerns at three timings), and FP #7 (winning consensus filed). The Quality Signal (0-10,000) provides a single continuous metric for architectural health that maps directly to L5 observability and L2.5 structural drift monitoring. The MCP integration (9 tools) provides the actuator side of the cybernetic feedback loop — agents can scan, baseline, and detect degradation autonomously. (Source: [[Research: sentrux.dev]])
 - **Anthropic Agent Skills** (Dec 2025): Three-tier progressive disclosure proven at scale. Within weeks, OpenAI, Google, GitHub, Cursor adopted the open standard. (Source: [[Source: SwirlAI Agent Skills Progressive Disclosure]])
 - **Blake Crosley Harness Pattern** (Apr 2026): "The harness is a programmable runtime with an LLM kernel." 84 hooks, 48 skills production system. "Hooks guarantee execution; prompts do not." (Source: [[Source: Blake Crosley Agent Architecture Guide]])
 - **Claude Code Architecture** (Mar-May 2026): Skills + hooks + subagents + memory as the four extension primitives. (Source: [[Source: Claude API Agent Skills Overview]])
@@ -312,7 +335,7 @@ All research from April-May 2026 remains valid. The skill-first architecture is 
 | **ADR-020** | YAML task DAG | Generated by harness-plan skill, not code. |
 | **ADR-022** | 7 drift patterns | In drift-monitor.ts (code — deterministic). |
 | **ADR-025** | GitHub Issues spec storage | Used by harness-spec skill. |
-| **ADR-013** | Biome + tsc + fallow gate | Invoked by harness-gate skill (bash). |
+| **ADR-013** | Biome + tsc + fallow + sentrux gate | Invoked by harness-gate skill (bash). sentrux adds architectural enforcement: cycles, modularity, depth, equality, redundancy. |
 | **ADR-016** | pi-subagents for L4 critic | Invoked by harness-critic skill. |
 
 ---

--- a/vault/wiki/modules/harness.md
+++ b/vault/wiki/modules/harness.md
@@ -9,6 +9,7 @@ sources:
   - "[[harness-implementation-plan]]"
   - "[[harness-control-frameworks]]"
   - "[[drift-detection-unified]]"
+  - "[[Research: sentrux.dev]]"
 related:
   - "[[harness-wiki-skill-mapping]]"
   - "[[harness-wiki-pipeline]]"
@@ -22,11 +23,11 @@ An **8-layer mandatory pipeline** with a **drift monitor layer** and **cross-cut
 ## Runtime Pipeline
 
 ```
-L1: Spec Hardening → L2: Structured Planning → L2.5: Drift Monitor
+L1: Spec Hardening → L2: Structured Planning → L2.5: Drift Monitor (+sentrux structural)
   ↓                                               ↓
-L3: Grounding Checkpoints → L4: Adversarial Verification → Phase 16: Lint+Format Gate
+L3: Grounding Checkpoints (+sentrux MCP) → L4: Adversarial Verification → Phase 16: Lint+Format+Arch Gate (+sentrux check)
   ↓
-L5: Automated Observability → L6: Persistent Memory → L7: Schema Orchestration → L8: Wiki Query
+L5: Automated Observability (+Quality Signal) → L6: Persistent Memory (+baselines) → L7: Schema Orchestration → L8: Wiki Query
 ```
 
 ## The 8 Layers (+ Drift Monitor)
@@ -54,6 +55,7 @@ L5: Automated Observability → L6: Persistent Memory → L7: Schema Orchestrati
 | Semantic Code Search | ck hybrid BM25+embeddings grep (Phase P13) |
 | Gitingest | Bulk external repo ingestion (Phase P15) |
 | Haiku Model Router | Route exploration to cheap model (Phase P25) |
+| **sentrux MCP (9 tools)** | Structural scan, health check, rules check, session baseline/diff — agent self-verifies architecture before committing (Phase P44) |
 
 ## Formal Models
 

--- a/vault/wiki/questions/Research-pi-vs-claude-code-agentic-orchestration-pipeline.md
+++ b/vault/wiki/questions/Research-pi-vs-claude-code-agentic-orchestration-pipeline.md
@@ -1,0 +1,87 @@
+---
+type: synthesis
+title: "Research: pi-vs-claude-code Agentic Orchestration Pipeline"
+created: 2026-05-03
+updated: 2026-05-03
+tags:
+  - research
+  - agentic-orchestration
+  - pi-agent
+  - harness
+status: developing
+related:
+  - "[[concepts/agentic-orchestration-pipeline]]"
+  - "[[concepts/agent-harness-architecture]]"
+  - "[[concepts/multi-agent-specialization]]"
+  - "[[concepts/context-engineering]]"
+  - "[[concepts/safety-defense-in-depth]]"
+  - "[[entities/pi-coding-agent]]"
+  - "[[entities/disler-indydevdan]]"
+  - "[[entities/opendev]]"
+sources:
+  - "[[sources/disler-pi-vs-claude-code]]"
+  - "[[sources/opendev-arxiv-2603.05344v1]]"
+  - "[[sources/martin-fowler-harness-engineering]]"
+  - "[[sources/mindstudio-four-agent-types]]"
+  - "[[sources/anthropic-effective-harnesses]]"
+---
+
+# Research: pi-vs-claude-code Agentic Orchestration Pipeline
+
+## Overview
+
+The `disler/pi-vs-claude-code` repository demonstrates that Pi Coding Agent's extension system can implement production-grade multi-agent orchestration entirely in user-space TypeScript. Three orchestration patterns emerge — subagent delegation, team dispatch, and sequential chaining — each with distinct use cases and implementation strategies. These patterns can be ported to our harness as `.pi/skills/` extensions backed by YAML configuration files. The broader research reveals that harness engineering (context management, safety, feedback loops) is as critical as orchestration itself, and mature systems like OpenDev provide reference architectures for both.
+
+## Key Findings
+
+1. **Pi extensions can implement full orchestration without core changes** (Source: [[sources/disler-pi-vs-claude-code]]). The three orchestration extensions (subagent-widget, agent-team, agent-chain) are clean TypeScript files that hook Pi's event system. Our harness can adopt identical patterns.
+
+2. **Three orchestration patterns cover the design space** (Source: [[sources/disler-pi-vs-claude-code]], [[sources/mindstudio-four-agent-types]]):
+   - **Subagent delegation** (fan-out): Spawn isolated agents for parallel subtasks. Best for exploration, analysis, background work.
+   - **Team dispatch** (specialist routing): Dispatcher selects specialist from roster. Best for domain-specific work.
+   - **Sequential chaining** (pipeline): Agents execute in order with `$INPUT` passing. Best for multi-phase workflows.
+
+3. **Schema-level isolation is more robust than runtime checks** (Source: [[sources/opendev-arxiv-2603.05344v1]]). Removing tools from a subagent's schema makes dangerous operations structurally impossible. The model cannot argue for capabilities it doesn't know exist. This should be our default safety strategy.
+
+4. **Context engineering is a first-class concern, not an afterthought** (Source: [[sources/opendev-arxiv-2603.05344v1]], [[sources/martin-fowler-harness-engineering]]). Staged compaction (5 graduated thresholds), event-driven reminders (24 templates, user-role injection), and dual-memory architecture (episodic + working) are proven techniques. Our harness lacks all three.
+
+5. **Harness = Guides + Sensors + Steering Loop** (Source: [[sources/martin-fowler-harness-engineering]]). Feedforward guides steer before action; feedback sensors observe after. The human iterates on both. Our `.pi/skills/` are feedforward; `wiki-lint` and `posthog-analyst` are feedback. We need more computational sensors.
+
+6. **Multi-model pipelines beat single-model agents** (Source: [[sources/mindstudio-four-agent-types]], industry pattern). Different pipeline stages benefit from different models (Opus for planning, Sonnet for building, Haiku for reviewing). Our harness should support per-stage model selection.
+
+7. **Safety requires defense-in-depth, not single-point checks** (Source: [[sources/opendev-arxiv-2603.05344v1]], [[sources/disler-pi-vs-claude-code]]). Five independent layers: prompt guardrails → schema gating → runtime approval → tool validation → lifecycle hooks. Our harness has none of these in structured form.
+
+## Key Entities
+
+- **[[entities/pi-coding-agent]]**: The foundation — open-source terminal coding agent with TypeScript extension API. Our harness platform.
+- **[[entities/disler-indydevdan]]**: Created the reference implementation of Pi orchestration extensions. Primary source of patterns.
+- **[[entities/opendev]]**: Most comprehensive reference architecture for terminal coding agents. Source of context engineering and safety patterns.
+
+## Key Concepts
+
+- **[[concepts/agentic-orchestration-pipeline]]**: Three orchestration patterns (subagent, team, chain) with design principles for implementation.
+- **[[concepts/agent-harness-architecture]]**: Scaffolding + Harness model. Feedforward guides + Feedback sensors in a steering loop.
+- **[[concepts/multi-agent-specialization]]**: Specialization by role, model, and tool set. Team composition via YAML config.
+- **[[concepts/context-engineering]]**: Staged compaction, dual-memory, event-driven reminders, lazy tool discovery, prompt caching.
+- **[[concepts/safety-defense-in-depth]]**: Five-layer architecture with schema gating as the primary strategy.
+
+## Contradictions
+
+- **Single agent vs Multi-agent overhead**: [[sources/mindstudio-four-agent-types]] warns that orchestration adds overhead and should only be used when a single agent demonstrably fails. [[sources/disler-pi-vs-claude-code]] shows orchestration as a default pattern. Resolution: Start with a single agent; add orchestration when context limits or specialization needs are clear. This aligns with our current approach where the `Agent` tool is used selectively.
+
+## Open Questions
+
+- How to implement event-driven system reminders in Pi's extension API? Pi's event system supports `tool_call` and `turn_end` events — these could drive reminder injection.
+- What's the right compaction strategy for our context window? Pi doesn't expose token counts to extensions — we may need to approximate or request API changes.
+- How to persist approval rules across sessions? Pi's extension lifecycle includes `session_start` and `session_shutdown` — rules could be loaded/saved in these hooks.
+- Can we implement 9-pass fuzzy editing in Pi's `edit` tool handler? Pi's extension API exposes `tool_call` events — we could intercept edit failures and retry with fuzzy matching.
+- What's the performance impact of context isolation per subagent? Spawning new Pi processes per subagent may be expensive. Thread-based subagents (like OpenDev) would be lighter.
+- How to implement the steering loop? Need a mechanism for humans to review harness performance and update guides/sensors. Our `wiki` + `posthog-analyst` pipeline is a start.
+
+## Sources
+
+- [[sources/disler-pi-vs-claude-code]]: disler, Feb 2026 — Reference implementation of Pi orchestration extensions
+- [[sources/opendev-arxiv-2603.05344v1]]: Nghi D. Q. Bui, Mar 2026 — Comprehensive terminal agent architecture paper
+- [[sources/martin-fowler-harness-engineering]]: Birgitta Böckeler, Apr 2026 — Harness engineering mental model and framework
+- [[sources/mindstudio-four-agent-types]]: MindStudio, Apr 2026 — Taxonomy of agent types and architecture decisions
+- [[sources/anthropic-effective-harnesses]]: Justin Young (Anthropic), 2025 — Authoritative harness definition

--- a/vault/wiki/questions/Research-sentrux-dev.md
+++ b/vault/wiki/questions/Research-sentrux-dev.md
@@ -1,0 +1,123 @@
+---
+type: synthesis
+title: "Research: sentrux.dev"
+created: 2026-05-03
+updated: 2026-05-03
+tags:
+  - research
+  - sentrux
+  - code-quality
+  - ai-coding
+status: developing
+related:
+  - "[[sentrux (tool)]]"
+  - "[[Quality Signal (sentrux)]]"
+  - "[[Five Root Cause Metrics (sentrux)]]"
+  - "[[sentrux Rules Engine]]"
+  - "[[sentrux MCP Integration]]"
+  - "[[harness-implementation-plan]]"
+  - "[[harness]]"
+sources:
+  - "[[sentrux-github-repo]]"
+  - "[[sentrux-dev-landing]]"
+  - "[[sentrux-docs-quality-signal]]"
+  - "[[sentrux-docs-root-cause-metrics]]"
+  - "[[sentrux-docs-rules-engine]]"
+  - "[[sentrux-docs-pro-architecture]]"
+---
+
+# Research: sentrux.dev
+
+## Overview
+sentrux is a real-time architectural sensor for AI-agent-written code. Built in Rust (MIT licensed), it computes a single Quality Signal score (0–10,000) from 5 graph-theoretic root cause metrics, visualizes the codebase as an interactive treemap, and integrates with AI coding agents via MCP (Model Context Protocol). First released March 11, 2026; already at v0.5.7 with 1.9k GitHub stars.
+
+## Key Findings
+
+- **Unique positioning:** sentrux positions itself as the missing feedback loop in AI-assisted development — the "sensor" that observes architectural reality while AI agents are the "actuator" making changes (Source: [[sentrux-dev-landing]])
+- **Mathematically grounded scoring:** Uses geometric mean of 5 independent graph-theoretic dimensions, justified by Nash Social Welfare theorem (1950). Claims to be "ungameable by design" (Source: [[sentrux-docs-quality-signal]])
+- **5 root cause metrics cover complete structural space:** 3 edge properties (modularity, acyclicity, depth) + 2 node properties (equality, redundancy) — each grounded in peer-reviewed theory (Newman 2004, Martin 2003, Lakos 1996, Gini 1912, Kolmogorov 1963) (Source: [[sentrux-docs-root-cause-metrics]])
+- **MCP-first AI agent integration:** 9 MCP tools allow agents to scan, baseline, check rules, and detect quality degradation per session — closing the feedback loop automatically (Source: [[sentrux-github-repo]])
+- **Pro tier via runtime plugin model:** Pro features ($15/month) live in a separately downloaded dylib, not in the free binary. Ed25519 license keys with offline validation and per-user watermarking for anti-piracy (Source: [[sentrux-docs-pro-architecture]])
+- **Rapid development velocity:** From initial commit to v0.5.7 with Pro architecture, Claude Code plugin, universal resolver, and 316+ tests in approximately one week (Source: [[sentrux-github-repo]])
+- **52 languages via tree-sitter:** Zero language-specific code in the Rust binary. All language knowledge in plugin.toml + tags.scm query files. New languages require zero Rust code (Source: [[sentrux-github-repo]])
+
+## Key Entities
+- [[sentrux (tool)]]: The open-source architectural sensor and quality governance tool
+- **yjing:** Primary author; GitHub user "sentrux"; appears as "yjing@sentrux.dev" in license keys
+- **claude:** Contributor account — likely represents AI-generated code contributions (the tool was partially built by Claude)
+
+## Key Concepts
+- [[Quality Signal (sentrux)]]: Single scalar score 0–10,000 via geometric mean of 5 normalized metrics
+- [[Five Root Cause Metrics (sentrux)]]: modularity, acyclicity, depth, equality, redundancy
+- [[sentrux Rules Engine]]: TOML-based architectural constraint system for CI and MCP
+- [[sentrux MCP Integration]]: 9-tool MCP server for AI agent feedback loops
+- **Feedback Loop (cybernetic):** sensor (sentrux) → signal → controller (AI agent) → actuator (code changes) → system (codebase) → loop
+
+## Contradictions
+
+- **Self-assessment gap:** The sentrux repo gives itself a "D" rating when analyzed by its own tool (Source: Reddit comment by ron3090). This raises questions about either the tool's calibration or the repo's code quality — both problematic for credibility.
+- **Rapid release pace vs stability:** 17 releases in a single day during launch. Reddit community flagged this as potentially "vibe-coded" with insufficient review and testing. Creator responded to specific feedback (swapped `dirs` crate for `std::env::home_dir()`) suggesting responsiveness but also rapid, reactive development.
+- **Conceptual strength vs practical utility:** Community feedback split between praising the concept (human-in-the-loop, feedback loop) and questioning practical usefulness — "it looks okay visually, but doesn't actually show anything useful" and metrics are "meaningless noise" without actionable drill-down.
+- **"Ungameable" claim:** The Nash Social Welfare theorem guarantees aggregation properties, not that individual metrics can't be gamed. The claim conflates mathematical properties of aggregation with practical impossibility of gaming.
+
+## Open Questions
+
+- **Production adoption unknown:** No evidence found of production usage beyond the creator. Tool is <2 months old. Listed as "developing" status.
+- **No independent reviews found:** No blog posts, technical analyses, or third-party evaluations beyond the Reddit launch thread comments. All documentation is from the creator.
+- **Accuracy of metrics across languages:** 52 languages supported via tree-sitter but accuracy of dependency graph extraction likely varies significantly by language maturity of tree-sitter grammars.
+- **Scalability limits unknown:** No data on performance with large codebases (100K+ files, monorepos). Treemap rendering with dependency edges at scale unverified.
+- **Pro plugin security model:** Runtime dylib loading has inherent security risks. The anti-piracy posture explicitly accepts that binary patching defeats all protections — what about malicious plugin substitution?
+- **Comparison with existing tools absent:** No positioning relative to SonarQube, CodeClimate, CodeScene, or other established code quality tools. sentrux claims uniqueness via MCP integration and geometric mean, but doesn't benchmark against alternatives.
+
+## Sources
+- [[sentrux-github-repo]]: GitHub repository, primary development source, MIT licensed
+- [[sentrux-dev-landing]]: Official marketing website (sentrux.dev)
+- [[sentrux-docs-quality-signal]]: Quality Signal scoring methodology documentation
+- [[sentrux-docs-root-cause-metrics]]: Detailed mathematical definitions of all 5 metrics
+- [[sentrux-docs-rules-engine]]: Rules engine TOML configuration and enforcement documentation
+- [[sentrux-docs-pro-architecture]]: Pro tier architecture, license system, business model
+
+## Harness Integration Map
+
+sentrux maps onto the ultimate-pi agentic harness at 5 integration points. See [[harness-implementation-plan]] for the updated build plan.
+
+| Harness Layer | What sentrux Provides | Replaces |
+|--------------|----------------------|----------|
+| **L2.5 Drift Monitor** | `session_start()`/`session_end()` — structural health baseline + degradation detection per agent session | Augments behavioral drift with structural drift signals |
+| **L3 Grounding** | `scan()` + `check_rules()` — agent gets real-time structural awareness before/after edits; verifies architectural constraints before committing | Adds architectural grounding to existing manual checkpoints |
+| **P20 Gate** | `sentrux check .` — CI-friendly exit 0/1: modularity, acyclicity, depth, equality, redundancy | Joins biome + tsc + fallow (dead code) as fourth deterministic gate |
+| **L5 Observability** | Quality Signal trending via `evolution` tool — continuous metric trackable across sessions | Adds structural dimension to Keep Rate + LLM-as-Judge |
+| **P44 Structural Gate** | Full Fallow replacement: dead code (redundancy), coupling (modularity), cycle detection (acyclicity), god files (equality), depth analysis — all in one tool with MCP + session diff + rules engine | **Replaces Fallow entirely** for P44a-g. Fallow retained only for dead code detection in P20 gate (complementary). |
+
+### What sentrux Does NOT Replace
+- **L1 Spec Hardening** — specification analysis (LLM evaluation)
+- **L2 Structured Planning** — task planning (LLM evaluation)
+- **L4 Adversarial Verification** — semantic code review, critic agents (LLM evaluation)
+- **P13 Semantic Code Search (ck)** — BM25+embeddings grep (different concern: semantic vs structural)
+- **P14 Think-in-Code** — coding paradigm enforcement (different concern: process vs structure)
+- **P15 Gitingest** — bulk external repo ingestion (different concern: ingestion vs analysis)
+- **P30 Browser Subagent** — visual UI verification (different domain)
+- **P43 TS Execution Layer** — TypeScript sandbox (different concern: execution vs analysis)
+- **L7 Schema Orchestration** — workflow DAG (different concern: orchestration vs analysis)
+- **L8 Wiki Query** — knowledge base search (different concern: retrieval vs analysis)
+
+### Token Budget Impact
+sentrux MCP calls add **0 LLM tokens** to the pipeline budget. All 9 tools are deterministic Rust computations — structural analysis happens outside the LLM context window. This replaces ~500-1,000 tokens of LLM-based structural review that Fallow required for interpretation of its JSON output.
+
+### Why sentrux Over Fallow
+| Capability | Fallow | sentrux |
+|-----------|--------|--------|
+| Dead code detection | Yes (redundancy metric) | Yes (redundancy metric) |
+| Duplication detection | Yes | Via redundancy |
+| Complexity (cyclomatic) | Yes | Via equality (Gini) — god file detection |
+| Boundary/coupling analysis | Yes | Yes (modularity + acyclicity) |
+| Dependency depth | No | Yes (Lakos 1996 levelization) |
+| Modularity (Newman 2004) | No | Yes |
+| Single scalar 0-10,000 score | No | Yes (Quality Signal) |
+| MCP server | Yes | Yes (9 tools vs Fallow's tool set) |
+| Session baseline/diff | No | Yes |
+| Rules engine (TOML constraints) | No | Yes |
+| 52 languages | TS/JS only | 52 languages |
+| Open source license | MIT | MIT (free binary) |
+
+**Decision:** sentrux is the primary structural quality tool. Fallow is retained only for TypeScript-specific dead code detection in the P20 gate (complementary, not competitive).

--- a/vault/wiki/sources/anthropic-effective-harnesses.md
+++ b/vault/wiki/sources/anthropic-effective-harnesses.md
@@ -1,0 +1,42 @@
+---
+type: source
+source_type: engineering-blog
+author: "Justin Young (Anthropic)"
+date_published: 2025
+url: https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents
+confidence: high
+tags:
+  - anthropic
+  - agent-harness
+  - long-running-agents
+  - context-windows
+key_claims:
+  - "A harness is the runtime framework that coordinates tool dispatch, context lifecycle, progress tracking, and clean handoffs between context windows"
+  - "Long-running agents need structured handoffs between context windows"
+  - "The harness must manage context as a finite resource across extended timeframes"
+---
+
+# Effective Harnesses for Long-Running Agents
+
+Anthropic Engineering Blog — 2025. By Justin Young.
+
+## Core Definition
+
+A harness is the runtime orchestration layer that wraps the core reasoning loop and coordinates:
+- Tool dispatch
+- Context lifecycle management
+- Safety enforcement
+- Session persistence
+- Progress tracking
+- Clean handoffs between context windows
+
+## Key Principles
+
+1. **Context windows are finite resources** — the harness must manage them explicitly across long timeframes
+2. **Structured handoffs** — when context fills, the harness must summarize and transfer state to a fresh window
+3. **Progress tracking** — agents must maintain awareness of what's been done across context boundaries
+4. **Safety invariants** — the harness enforces constraints that persist across context resets
+
+## Relevance
+
+This is the authoritative definition of "harness" as used in the agent engineering community. It maps directly to disler's Pi extensions (subagent-widget, agent-team, agent-chain) and OpenDev's four-layer architecture. Our harness implementation should treat context as a managed resource with explicit handoff protocols.

--- a/vault/wiki/sources/disler-pi-vs-claude-code.md
+++ b/vault/wiki/sources/disler-pi-vs-claude-code.md
@@ -1,0 +1,69 @@
+---
+type: source
+source_type: github-repo
+author: disler (IndyDevDan)
+date_published: 2026-02-23
+url: https://github.com/disler/pi-vs-claude-code
+confidence: high
+tags:
+  - pi-agent
+  - claude-code
+  - agentic-coding
+  - multi-agent
+  - extensions
+key_claims:
+  - "Pi Coding Agent is the only real open-source competitor to Claude Code"
+  - "Pi's extension system enables UI customization, agent orchestration, safety auditing, and cross-agent integrations"
+  - "Extensions compose via multiple -e flags: subagent-widget, agent-team, agent-chain, damage-control, pi-pi"
+  - "Pi supports every major AI model provider (OpenAI, Anthropic, Google, OpenRouter)"
+  - "Agent teams dispatch work to specialists via teams.yaml; agent chains pipeline steps sequentially via agent-chain.yaml"
+---
+
+# disler/pi-vs-claude-code
+
+GitHub repository by IndyDevDan (disler) — 928 stars, 244 forks. A collection of customized Pi Coding Agent instances demonstrating how to hedge against Claude Code in the agentic coding market.
+
+## What It Provides
+
+**15+ production extensions** covering the full agent lifecycle:
+
+### Multi-Agent Orchestration (3 extensions)
+- **subagent-widget**: `/sub <task>` spawns background Pi subagents with live-progress widgets
+- **agent-team**: Dispatcher-only orchestrator — primary agent delegates to named specialists via `dispatch_agent` tool, shows grid dashboard
+- **agent-chain**: Sequential pipeline orchestrator — chains agents where output feeds into next step (`$INPUT`, `$ORIGINAL` variables). Example: `plan-build-review` pipeline
+
+### Safety & Control (2 extensions)
+- **damage-control**: Real-time safety auditing — intercepts dangerous bash patterns via regex, enforces path-based access controls from `.pi/damage-control-rules.yaml`. Block levels: Zero Access, Read-Only, No-Delete, Dangerous Commands (some with `ask: true` confirmation)
+- **purpose-gate**: Session intent declaration on startup, blocks prompts until answered
+
+### UI & DX (7 extensions)
+- **pure-focus**: Distraction-free mode (no footer/status)
+- **minimal**: Compact footer with model name + 10-block context meter
+- **tool-counter**: Rich two-line footer (model, context, tokens, cost + cwd/branch, per-tool tally)
+- **tool-counter-widget**: Live-updating above-editor per-tool call counts
+- **session-replay**: Scrollable timeline overlay of session history
+- **theme-cycler**: Keyboard shortcuts to cycle custom themes
+- **system-select**: `/system` command to switch between agent personas from `.pi/agents/`
+
+### Meta & Cross-Agent (2 extensions)
+- **cross-agent**: Scans `.claude/`, `.gemini/`, `.codex/` dirs for commands/skills/agents and registers them in Pi
+- **pi-pi**: Meta-agent that builds Pi agents using parallel research experts (ext-expert, theme-expert, tui-expert)
+
+## Key Architecture Insights
+
+**Agent Teams** configured in `.pi/agents/teams.yaml`:
+```yaml
+frontend: [planner, builder, bowser]
+backend: [architect, implementer, tester]
+```
+Individual agent personas live as `.md` files in `.pi/agents/`.
+
+**Agent Chains** defined in `.pi/agents/agent-chain.yaml` as sequential steps with `$INPUT` injection.
+
+**Damage Control Rules** in `.pi/damage-control-rules.yaml` with four path policies (Zero Access, Read-Only, No-Delete, Dangerous Commands).
+
+**Stacking**: Extensions compose — `pi -e extensions/minimal.ts -e extensions/cross-agent.ts`.
+
+## Relevance to Our Harness
+
+The repo demonstrates that Pi's extension system can implement the full orchestration patterns (subagent delegation, team dispatch, sequential chaining) entirely in user-space TypeScript, without modifying the core agent. This means our harness can adopt these patterns as `.pi/skills/` extensions rather than core code changes.

--- a/vault/wiki/sources/martin-fowler-harness-engineering.md
+++ b/vault/wiki/sources/martin-fowler-harness-engineering.md
@@ -1,0 +1,73 @@
+---
+type: source
+source_type: article
+author: "Birgitta Böckeler (Thoughtworks)"
+date_published: 2026-04-02
+url: https://martinfowler.com/articles/harness-engineering.html
+confidence: high
+tags:
+  - harness-engineering
+  - context-engineering
+  - agent-trust
+  - feedback-loops
+key_claims:
+  - "Agent = Model + Harness. A harness is everything in an AI agent except the model itself"
+  - "Feedforward guides (before action) + Feedback sensors (after action) form the steering loop"
+  - "Computational controls (deterministic, fast) vs Inferential controls (LLM-based, semantic)"
+  - "Three regulation categories: Maintainability, Architecture Fitness, Behaviour"
+  - "The human's job is to steer the agent by iterating on the harness"
+  - "Harness templates can encode topologies (CRUD service, event processor, data dashboard)"
+---
+
+# Harness Engineering for Coding Agent Users
+
+Martin Fowler blog — April 2026. By Birgitta Böckeler, Distinguished Engineer at Thoughtworks.
+
+## Core Mental Model
+
+**Agent = Model + Harness**. The harness is everything except the model: system prompts, tools, feedback loops, approval gates, context management.
+
+Three concentric circles:
+1. **Model** (core)
+2. **Builder harness** (coding agent's built-in infrastructure)
+3. **User harness** (what we build — guides + sensors specific to our use case)
+
+## Feedforward and Feedback
+
+| Direction | Purpose | Examples |
+|-----------|---------|----------|
+| **Feedforward (Guides)** | Steer agent *before* it acts | AGENTS.md, Skills, coding conventions, architecture docs |
+| **Feedback (Sensors)** | Observe *after* agent acts, enable self-correction | Linters, tests, review agents, type checkers |
+
+Two execution types:
+- **Computational**: Deterministic, fast (tests, linters, type checkers, structural analysis)
+- **Inferential**: LLM-based, semantic (AI code review, "LLM as judge")
+
+## The Steering Loop
+
+Human's role: Iterate on the harness. When issues recur, improve feedforward guides or feedback sensors to make them less probable. Agents can help build harness components (write structural tests, generate linter rules, create how-to guides).
+
+## Three Regulation Categories
+
+1. **Maintainability Harness**: Code quality, style, complexity, test coverage. Computational sensors catch structural issues reliably. LLMs partially address semantic judgment (duplicate code, brute-force fixes) but expensively.
+2. **Architecture Fitness Harness**: Performance requirements, logging standards, observability. Fitness functions as feedback sensors.
+3. **Behaviour Harness**: Functional correctness. The hardest category — still relies heavily on human review and manual testing. AI-generated tests put too much faith in AI.
+
+## Key Timing Principle: Keep Quality Left
+
+Checks distributed across the change lifecycle by cost and speed:
+- **Pre-commit**: Linters, fast tests, basic code review agent
+- **Post-integration pipeline**: Mutation testing, broad architecture review
+- **Continuous**: Dead code detection, dependency scanning, SLO monitoring
+
+## Harness Templates
+
+For enterprises with common service topologies (CRUD APIs, event processors, dashboards), harness templates bundle guides + sensors for each topology. Teams pick tech stacks partly based on available harnesses.
+
+## Relevance to Our Harness
+
+- Our `.pi/skills/` system implements feedforward guides
+- Our `wiki-lint` and `posthog-analyst` skills implement inferential feedback sensors
+- The steering loop is what we're building: improve harness as agents make mistakes
+- We need computational sensors: pre-commit hooks, structural tests, architecture fitness checks
+- Harness templates are our `lean-ctx` and `wiki` patterns — reusable across projects

--- a/vault/wiki/sources/mindstudio-four-agent-types.md
+++ b/vault/wiki/sources/mindstudio-four-agent-types.md
@@ -1,0 +1,68 @@
+---
+type: source
+source_type: article
+author: MindStudio
+date_published: 2026-04
+url: https://www.mindstudio.ai/blog/four-types-of-ai-agents-explained/
+confidence: medium
+tags:
+  - agent-types
+  - multi-agent
+  - orchestration
+  - architecture
+key_claims:
+  - "Four distinct agent types with different architectures: Coding Harnesses, Dark Factories, Auto Research, Orchestration"
+  - "Mismatching agent type to task is a primary cause of AI system failure in production"
+  - "Architecture matters more than model choice for multi-agent systems"
+  - "Orchestration agents add overhead — start simple, add complexity only when needed"
+---
+
+# Four Types of AI Agents Explained
+
+MindStudio blog — 2026. Classifies production AI agents into four architecturally distinct types.
+
+## The Four Types
+
+### 1. Coding Harnesses
+Operate within bounded technical environments (codebases). Tight feedback loop with deterministic execution environment — write code, run tests, see results, revise. Tools: file system access, terminal execution, test runners, code search, version control. Examples: Claude Code, GitHub Copilot Workspace, Devin.
+
+**Use when**: Task involves writing/editing/debugging code with testable success conditions.
+
+**Avoid when**: Task requires cross-domain reasoning or multi-agent coordination.
+
+### 2. Dark Factories
+Fully automated, humanless pipelines processing work at scale. Ingest inputs → process through defined steps → produce outputs. Run unattended on schedules or events.
+
+**Use when**: High volume, structurally similar inputs, scheduled/event-driven processing.
+
+**Avoid when**: Tasks require dynamic judgment or high-variance inputs.
+
+### 3. Auto Research Agents
+Autonomous information gathering: decompose questions, search multiple sources, evaluate relevance, synthesize findings. Dynamic retrieval path — decides what to retrieve based on findings.
+
+**Use when**: Answer requires multiple sources, retrieval path uncertain upfront, synthesis needed.
+
+**Avoid when**: Information available in structured database, simple RAG would suffice.
+
+### 4. Orchestration Agents
+Coordinate other agents: decompose complex goals, assign subtasks to specialists, handle dependencies, assemble final output. Acts as project manager, not implementer.
+
+**Use when**: Task requires multiple distinct capabilities or parallel workstreams.
+
+**Avoid when**: Single agent can handle the task — orchestration adds overhead (more LLM calls, more latency, more failure points).
+
+## Production Pattern: Combined Types
+
+Real systems combine types under an orchestrator. Example competitive intelligence system:
+1. Orchestrator receives brief
+2. Dispatches auto research agent for web gathering
+3. Dispatches dark factory for high-volume review processing
+4. Dispatches coding harness for structured data analysis
+5. Orchestrator synthesizes all outputs
+
+## Relevance to Our Harness
+
+- Our `wiki-autoresearch` skill is an auto research agent
+- Our `Agent` tool (subagent spawning) maps to orchestration
+- Our core coding loop is a coding harness
+- The key insight: match architecture to task, don't over-architect

--- a/vault/wiki/sources/opendev-arxiv-2603.05344v1.md
+++ b/vault/wiki/sources/opendev-arxiv-2603.05344v1.md
@@ -1,0 +1,79 @@
+---
+type: source
+source_type: academic-paper
+author: "Nghi D. Q. Bui (OpenDev)"
+date_published: 2026-03-05
+url: https://arxiv.org/html/2603.05344v1
+confidence: high
+tags:
+  - terminal-agents
+  - context-engineering
+  - agent-architecture
+  - safety
+  - multi-model
+key_claims:
+  - "OpenDev is the first comprehensive technical report for an open-source, terminal-native, interactive coding agent"
+  - "Compound AI system architecture with per-workflow LLM binding (action, thinking, critique, vision, compact models)"
+  - "Defense-in-depth safety with 5 independent layers: prompt guardrails, schema gating, runtime approval, tool validation, lifecycle hooks"
+  - "Adaptive Context Compaction (ACC) with 5 graduated stages reduces peak context consumption by ~54%"
+  - "Event-driven system reminders counteract instruction fade-out in long-running sessions"
+  - "Dual-agent architecture separating planning from execution via schema-level tool restrictions"
+---
+
+# Building AI Coding Agents for the Terminal: Scaffolding, Harness, Context Engineering, and Lessons Learned
+
+arXiv:2603.05344v1 — March 2026. OpenDev technical report by Nghi D. Q. Bui.
+
+## Core Architecture
+
+Four-layer system: Entry & UI → Agent → Tool & Context → Persistence.
+
+### Scaffolding vs Harness
+- **Scaffolding**: System prompt compilation, tool schema building, subagent registration — runs once before first prompt
+- **Harness**: Runtime orchestration — tool dispatch, context management, safety enforcement, session persistence
+
+### Compound AI System
+Five model roles with fallback chains:
+1. **Action model** — primary execution, tool-based reasoning
+2. **Thinking model** — extended reasoning without tool access (prevents premature action)
+3. **Critique model** — self-evaluation (Reflexion-inspired, selective)
+4. **Vision model** — screenshots/images
+5. **Compact model** — fast summarization during compaction
+
+### Extended ReAct Loop
+Four phases per iteration:
+- **Phase 0**: Staged context management (5 thresholds: 70%→80%→85%→90%→99%)
+- **Phase 1**: Thinking (4 depth levels, HIGH includes self-critique)
+- **Phase 2**: Action (LLM with full tool schemas)
+- **Phase 3**: Decision/dispatch with doom-loop detection (MD5 fingerprinting, 3-repeat threshold)
+
+## Context Engineering Highlights
+
+### Adaptive Context Compaction (ACC)
+Five graduated stages: Warning (70%) → Observation Masking (80%) → Fast Pruning (85%) → Aggressive Masking (90%) → Full Compaction (99%). Each stage applies progressively aggressive reduction.
+
+### System Reminders
+24 named reminders organized into 6 categories. Injected as `role: user` messages at maximum recency. Governed by guardrail counters (one-shot flags, attempt budgets). Addresses attention-decay where agents violate instructions after 30+ tool calls.
+
+### Dual-Memory Architecture
+- **Episodic memory**: LLM-generated summary of full history (regenerated every 5 messages from full history to prevent drift)
+- **Working memory**: Last 6 exchanges verbatim for operational detail
+
+## Safety Architecture (Defense-in-Depth)
+
+1. **Prompt-Level Guardrails** — security policy in system prompt
+2. **Schema-Level Tool Restrictions** — plan-mode whitelist, per-subagent allowed_tools
+3. **Runtime Approval System** — Manual/Semi-Auto/Auto levels, pattern/command/prefix/danger rules
+4. **Tool-Level Validation** — DANGEROUS_PATTERNS blocklist, stale-read detection, output truncation
+5. **Lifecycle Hooks** — pre-tool blocking (exit code 2), argument mutation, JSON stdin protocol
+
+Key insight: "Make unsafe tools invisible, not blocked" — removing tools from schema is more robust than runtime permission checks.
+
+## Lessons for Our Harness
+
+- Separate thinking from action (tool-free thinking phase produces better reasoning)
+- Inject reminders at decision points, not upfront (use `role: user`)
+- Treat context as a budget with graduated reduction (not binary emergency compaction)
+- Schema gating > runtime permission checks for safety
+- Design tools to absorb LLM imprecision (9-pass fuzzy edit matching chain)
+- Bound every resource that grows with session length (iteration caps, nudge budgets, undo history)

--- a/vault/wiki/sources/sentrux-dev-landing.md
+++ b/vault/wiki/sources/sentrux-dev-landing.md
@@ -1,0 +1,40 @@
+---
+type: source
+source_type: website
+title: "sentrux.dev Landing Page"
+author: sentrux
+date_fetched: 2026-05-03
+url: https://sentrux.dev
+confidence: high
+key_claims:
+  - "The sensor that closes the feedback loop for AI coding agents"
+  - "5 root cause metrics, one score, geometric mean — ungameable by design"
+  - "Classical cybernetics (Wiener 1948, Tsien 1954) — loop converges naturally like gradient descent"
+  - "36K lines of Rust, MIT Licensed, Open Source"
+tags:
+  - sentrux
+  - code-quality
+  - ai-coding
+---
+
+# sentrux.dev Landing Page
+
+Official marketing site for sentrux. Built with Astro. Available in English, 中文, 日本語, Deutsch.
+
+## Positioning
+"Your AI writes code at machine speed. Without structural governance, your codebase decays at machine speed too. sentrux is the governor."
+
+## The Problem Narrative
+AI agents start strong but silent architectural degradation compounds. Without a sensor observing actual structure, nobody notices until too late. The code your AI writes today is the context it reads tomorrow.
+
+## Key Sections
+1. **Hero:** Quality Signal visualization (score 7342 example)
+2. **Problem:** Codebase decay narrative
+3. **5 Metrics:** modularity, acyclicity, depth, equality, redundancy — each grounded in academic theory
+4. **Install:** brew, curl, cargo install, build from source
+5. **MCP Integration:** Agent workflow with scan/session_start/session_end
+6. **Features:** Live treemap, quality gate, rules engine, session diff, 52 languages, pure Rust
+7. **The Feedback Loop:** Cybernetic model — sensor → signal → controller → actuator → system
+
+## Live Demo
+scan.sentrux.dev — browser-based live treemap

--- a/vault/wiki/sources/sentrux-docs-pro-architecture.md
+++ b/vault/wiki/sources/sentrux-docs-pro-architecture.md
@@ -1,0 +1,75 @@
+---
+type: source
+source_type: documentation
+title: "sentrux Pro Architecture"
+author: sentrux
+date_published: 2026-03-19
+date_fetched: 2026-05-03
+url: https://raw.githubusercontent.com/sentrux/sentrux/main/docs/pro-architecture.md
+confidence: high
+key_claims:
+  - "Free binary = 100% public source, fully functional"
+  - "Pro features live in runtime-loaded pro.dylib, not behind if-flags"
+  - "Ed25519 license keys with offline validation, no server call needed"
+  - "Per-user watermarked dylib for anti-piracy"
+  - "Pricing: Free / Pro $15/month / Team $40/month/seat"
+tags:
+  - sentrux
+  - licensing
+  - business-model
+---
+
+# sentrux Pro Architecture
+
+## Design Principles
+1. Free binary = 100% public source. Anyone can `cargo build` and verify.
+2. Pro features live in pro.dylib, not behind `if tier.is_pro()` flags.
+3. License key = Ed25519 signed JSON. Offline validation, no server needed.
+4. Per-user watermarked dylib. Each download contains buyer's identity.
+5. Source-available Pro code (BSL license — read/audit, not redistribute).
+
+## License Key Format
+```json
+{
+  "user": "github:yjing",
+  "tier": "pro",
+  "issued": "2026-03-18",
+  "expires": "2026-04-18",
+  "id": "lic_...",
+  "sig": "base64_ed25519_signature"
+}
+```
+Validation: parse JSON → verify Ed25519 sig → check expiry. No server call.
+
+## Pro Features (vs Free)
+| Feature | Free | Pro |
+|---------|------|-----|
+| Scanning (52 languages) | Yes | Yes |
+| Quality signal, treemap, 3 color modes | Yes | Yes |
+| MCP server (scores), rules engine, quality gate | Yes | Yes |
+| MCP diagnostics (which files to fix) | — | Yes |
+| 9 color modes (Age, Churn, Risk, Git, etc.) | — | Yes |
+| File detail panel (per-function metrics) | — | Yes |
+| Evolution details (hotspots, coupling, bus factor) | — | Yes |
+| What-if analysis | — | Yes |
+
+## Anti-Piracy Posture
+Defense in depth: pro code in dylib, Ed25519 validation, per-user watermark, watermark-license cross-check, telemetry. Accepts that binary patching is always possible — "tiny number of people who crack a $15/month dev tool weren't going to pay."
+
+## Build Pipeline
+Public repo CI builds free binary. Private repo CI builds base pro.dylib (no watermark). CDN Worker watermarks and serves on valid license request.
+
+## CLI Commands
+```bash
+sentrux login              # GitHub OAuth → purchase
+sentrux pro activate <key> # saves license, downloads watermarked dylib
+sentrux pro status         # shows tier, features
+sentrux pro deactivate     # back to free
+```
+
+## Revenue Model
+| Tier | Price | Features |
+|------|-------|----------|
+| Free | $0 | Full scanning, scoring, treemap, 3 colors, MCP scores, rules |
+| Pro | $15/mo | +6 colors, diagnostics, what-if, C4, evolution, file detail |
+| Team | $40/mo/seat | +shared dashboard, drift alerts, PR annotations, SSO |

--- a/vault/wiki/sources/sentrux-docs-quality-signal.md
+++ b/vault/wiki/sources/sentrux-docs-quality-signal.md
@@ -1,0 +1,46 @@
+---
+type: source
+source_type: documentation
+title: "sentrux Docs — Quality Signal"
+author: sentrux
+date_fetched: 2026-05-03
+url: https://sentrux.dev/docs/quality-signal/
+confidence: high
+key_claims:
+  - "Quality Signal = (modularity × acyclicity × depth × equality × redundancy)^(1/5) × 10000"
+  - "Geometric mean chosen via Nash Social Welfare theorem (1950)"
+  - "Pareto optimal, symmetric, independent dimensions"
+tags:
+  - sentrux
+  - quality-metrics
+  - geometric-mean
+---
+
+# sentrux Docs: Quality Signal
+
+## Formula
+```
+quality_signal = (modularity × acyclicity × depth × equality × redundancy)^(1/5) × 10000
+```
+Each metric normalized to [0, 1]. Geometric mean then scaled to 0–10,000.
+
+## Why Geometric Mean?
+Nash Social Welfare theorem (1950) proves geometric mean is the unique aggregation satisfying:
+- **Pareto optimality:** if all scores improve, signal improves
+- **Symmetry:** all root causes weighted equally
+- **Independence:** irrelevant dimensions don't affect result
+
+## Why Not Letter Grades?
+Letter grades (A-F) collapse information. A codebase could have D cyclicity but A in everything else — same overall grade as B across the board. Continuous score preserves resolution.
+
+## Why Not 20 Proxy Metrics?
+Proxy metrics correlate but don't capture root causes. High coupling score + low cohesion score = measuring same thing twice (low modularity). Redundant metrics create illusion of thoroughness.
+
+## Normalization
+Each metric mapped to [0, 1] to ensure equal weight before geometric mean.
+
+## Convergence
+Quality Signal is designed to improve monotonically under correct agent action. Like gradient descent — no artificial stopping point.
+
+## Theoretical Foundation
+Grounded in Nash (1950), Newman (2004), Martin (2003), Lakos (1996), Gini (1912), Kolmogorov (1963).

--- a/vault/wiki/sources/sentrux-docs-root-cause-metrics.md
+++ b/vault/wiki/sources/sentrux-docs-root-cause-metrics.md
@@ -1,0 +1,57 @@
+---
+type: source
+source_type: documentation
+title: "sentrux Docs — Root Cause Metrics"
+author: sentrux
+date_fetched: 2026-05-03
+url: https://sentrux.dev/docs/root-cause-metrics/
+confidence: high
+key_claims:
+  - "5 metrics cover 3 edge properties + 2 node properties of a directed attributed graph"
+  - "Adding more metrics would overlap or measure outside static analysis"
+tags:
+  - sentrux
+  - code-metrics
+  - graph-theory
+---
+
+# sentrux Docs: Root Cause Metrics
+
+## 1. Modularity
+- **Theory:** Newman 2004, graph community detection
+- **Formula:** Q = (1/m) × Σ [A_ij - k_out_i × k_in_j / m] × δ(c_i, c_j)
+- **Range:** [-0.5, 1.0]; Q > 0.3 = significant modular structure
+- **Ungameable:** Adding useless edges moves graph toward random, decreasing Q
+- **Replaces:** coupling, cohesion, god files, hotspots (all symptoms of low Q)
+
+## 2. Acyclicity
+- **Theory:** Martin 2003, Acyclic Dependencies Principle
+- **Computation:** Tarjan's SCC algorithm counts strongly connected components >1 member
+- **Normalization:** score = 1/(1 + cycle_count) — sigmoid
+- **Why:** Cycles make build order undefined, change propagation unpredictable
+
+## 3. Depth
+- **Theory:** Lakos 1996, levelization
+- **Computation:** Longest dependency chain via iterative DFS from entry points
+- **Normalization:** score = 1/(1 + depth/8) — midpoint at depth=8
+- **Independent from modularity:** Graph can have perfect Q but still 20-deep chain
+
+## 4. Equality (Gini Coefficient)
+- **Theory:** Gini 1912, wealth inequality coefficient adapted to code
+- **Formula:** G = Σ(2i - n - 1) × x_i / (n × Σ x_i); score = 1 - G
+- **Why matters:** God files are the #1 source of AI agent confusion
+
+## 5. Redundancy
+- **Theory:** Kolmogorov complexity — gap between actual and minimum equivalent code
+- **Impact:** Every line of dead/duplicate code expands AI agent's search space
+
+## Why Exactly 5?
+| Dimension | What it captures | Property of |
+|-----------|-----------------|-------------|
+| Modularity | Edge clustering | Edges |
+| Acyclicity | Circular edges | Edges |
+| Depth | Edge chain length | Edges |
+| Equality | Node property concentration | Nodes |
+| Redundancy | Unnecessary nodes | Nodes |
+
+3 edge properties + 2 node properties = 5 total. Complete coverage of directed attributed graph structure under static analysis.

--- a/vault/wiki/sources/sentrux-docs-rules-engine.md
+++ b/vault/wiki/sources/sentrux-docs-rules-engine.md
@@ -1,0 +1,58 @@
+---
+type: source
+source_type: documentation
+title: "sentrux Docs — Rules Engine"
+author: sentrux
+date_fetched: 2026-05-03
+url: https://sentrux.dev/docs/rules-engine/
+confidence: high
+key_claims:
+  - "Rules engine defines architectural constraints in .sentrux/rules.toml"
+  - "Enforces in CI, before merges, or via MCP"
+tags:
+  - sentrux
+  - architecture-governance
+  - ci
+---
+
+# sentrux Docs: Rules Engine
+
+## Configuration File
+`.sentrux/rules.toml` at project root.
+
+## Constraint Types
+
+### Global Constraints
+```toml
+[constraints]
+max_cycles = 0
+max_coupling = "B"
+max_cc = 25
+no_god_files = true
+```
+
+### Layer Definitions
+```toml
+[[layers]]
+name = "core"
+paths = ["src/core/*"]
+order = 0
+```
+Higher layers can depend on lower, not vice versa.
+
+### Boundary Rules
+```toml
+[[boundaries]]
+from = "src/app/*"
+to = "src/core/internal/*"
+reason = "App must not depend on core internals"
+```
+
+## Running Checks
+```bash
+sentrux check .     # exit 0 = pass, 1 = fail
+```
+CI integration: add `sentrux check .` to GitHub Actions.
+
+## MCP Integration
+Agent calls `check_rules()` → { pass: bool, violations: [...] }. Agent sees violations and fixes before human notices.

--- a/vault/wiki/sources/sentrux-github-repo.md
+++ b/vault/wiki/sources/sentrux-github-repo.md
@@ -1,0 +1,56 @@
+---
+type: source
+source_type: github-repository
+title: "sentrux GitHub Repository"
+author: sentrux
+date_published: 2026-03-11
+date_fetched: 2026-05-03
+url: https://github.com/sentrux/sentrux
+confidence: high
+key_claims:
+  - "Real-time architectural sensor that helps AI agents close the feedback loop"
+  - "5 root cause metrics, one continuous score 0–10000"
+  - "52 languages via tree-sitter plugins, zero language-specific code in binary"
+  - "MCP server with 9 tools for AI agent integration"
+  - "Rules engine with TOML-based constraint definitions"
+  - "Pure Rust, single binary, no runtime dependencies"
+  - "MIT License, 1.9k stars, 168 forks"
+tags:
+  - code-quality
+  - static-analysis
+  - ai-coding
+  - mcp
+  - rust
+  - treemap
+---
+
+# sentrux GitHub Repository
+
+Primary development repository for sentrux. Public, MIT-licensed.
+
+## Stats (as of May 2026)
+- **Stars:** 1,900+
+- **Forks:** 168
+- **Releases:** 37 (latest: v0.5.7, Mar 18, 2026)
+- **Commits:** 318
+- **Contributors:** 4 (claude, v1b3coder, sentrux, trevorsilence)
+- **Languages:** Rust 87.5%, HTML 7.2%, Tree-sitter Query 5.2%
+
+## Architecture
+- **sentrux-core:** library crate (analysis, metrics, MCP server, GUI panels)
+- **sentrux-bin:** binary crate (GUI, CLI, MCP entry points)
+- **plugins/:** git submodule containing tree-sitter grammars
+- **.claude-plugin:** Claude Code plugin with MCP server and marketplace config
+
+## Key Features
+1. Real-time treemap visualization with dependency edges
+2. 5 root cause metrics aggregated via geometric mean (Nash Social Welfare theorem)
+3. Quality gate for CI (`sentrux check .` exits 0 or 1)
+4. Session baseline/diff comparison (`sentrux gate --save / sentrux gate .`)
+5. MCP server (9 tools): scan, health, session_start, session_end, rescan, check_rules, evolution, dsm, test_gaps
+6. Rules engine (.sentrux/rules.toml) with layers, boundaries, constraints
+7. Plugin system for adding languages (zero Rust code required)
+8. Pro tier with runtime dylib plugin model, Ed25519 license keys
+
+## Development Velocity
+Rapid iteration: from initial commit (Mar 11, 2026) to v0.5.7 with Pro architecture, Claude Code plugin, universal resolver, and 316+ tests in ~1 week.


### PR DESCRIPTION
…experts

- Add 10 pi-pi domain expert agent definitions (orchestrator + 9 experts covering agents, CLI, config, extensions, keybindings, prompts, skills, themes, TUI)
- Integrate sentrux MCP (9 tools) into harness pipeline replacing Fallow with P44 phases
- Add structural quality gate, rules engine, session baseline/diff to L2.5 drift monitor
- Expand wiki with new concepts (agent harness architecture, orchestration pipeline, sentrux MCP)
- Add wiki entities (sentrux, opendev, disler-indydevdan, pi-coding-agent)
- Add 11 wiki sources from anthropic, martin fowler, mindstudio, opendev arxiv, sentrux docs
- Update wiki-autoresearch skill with explicit topic extraction rules
- Fix settings.json trailing comma