### PR TITLE
feat(harness): add pi-model-router activation to harness setup

### DIFF
--- a/.pi/model-router.json
+++ b/.pi/model-router.json
@@ -1,0 +1,95 @@
+{
+    "defaultProfile": "auto",
+    "debug": false,
+    "classifierModel": "opencode-go/glm-5",
+    "phaseBias": 0.5,
+    "maxSessionBudget": 1.0,
+    "largeContextThreshold": 100000,
+    "rules": [
+        {
+            "matches": [
+                "deploy",
+                "production",
+                "release"
+            ],
+            "tier": "high",
+            "reason": "Safety check for production tasks"
+        },
+        {
+            "matches": "changelog",
+            "tier": "low"
+        }
+    ],
+    "profiles": {
+        "auto": {
+            "high": {
+                "model": "opencode-go/deepseek-v4-pro",
+                "thinking": "high",
+                "fallbacks": [
+                    "github-copilot/claude-opus-4.7",
+                    "github-copilot/gpt-5.5"
+                ]
+            },
+            "medium": {
+                "model": "opencode-go/mimo-v2.5",
+                "thinking": "medium",
+                "fallbacks": [
+                    "github-copilot/claude-sonnet-4.6"
+                ]
+            },
+            "low": {
+                "model": "opencode-go/glm-5.1",
+                "thinking": "low",
+                "fallbacks": [
+                    "github-copilot/gpt-5.4-mini"
+                ]
+            }
+        },
+        "cheap": {
+            "high": {
+                "model": "opencode-go/deepseek-v4-flash",
+                "thinking": "low",
+                "fallbacks": [
+                    "github-copilot/gpt-5.4-mini"
+                ]
+            },
+            "medium": {
+                "model": "opencode-go/minimax-m2.7",
+                "thinking": "off",
+                "fallbacks": [
+                    "github-copilot/claude-haiku-4.5"
+                ]
+            },
+            "low": {
+                "model": "opencode-go/glm-5",
+                "thinking": "off",
+                "fallbacks": [
+                    "github-copilot/claude-haiku-4.5"
+                ]
+            }
+        },
+        "deep": {
+            "high": {
+                "model": "opencode-go/deepseek-v4-pro",
+                "thinking": "xhigh",
+                "fallbacks": [
+                    "github-copilot/claude-opus-4.7"
+                ]
+            },
+            "medium": {
+                "model": "opencode-go/kimi-k2.6",
+                "thinking": "medium",
+                "fallbacks": [
+                    "github-copilot/claude-sonnet-4.6"
+                ]
+            },
+            "low": {
+                "model": "opencode-go/mimo-v2.5",
+                "thinking": "low",
+                "fallbacks": [
+                    "github-copilot/gpt-5.4"
+                ]
+            }
+        }
+    }
+}

--- a/.pi/prompts/harness-setup.md
+++ b/.pi/prompts/harness-setup.md
@@ -285,6 +285,27 @@ Verify each package:
 | `@posthog/pi` | Analytics event capture | F0 |
 | `pi-lean-ctx` | Context runtime (read/bash/find/grep/MCP bridge) | F0 |
 | `@tintinweb/pi-subagents` | L4 critic sub-agent spawn/control | P16 |
+| `@yeliu84/pi-model-router` | Per-turn intelligent model routing (auto high/medium/low tier selection) | F0 |
+
+## Step 3.5 — Model Router Configuration
+
+Verify the model router is installed and configured:
+
+```bash
+# Verify package installed
+ls .pi/npm/node_modules/@yeliu84/pi-model-router/package.json 2>/dev/null && echo "✓ model-router package" || echo "✗ model-router package — run: cd .pi/npm && npm install"
+
+# Verify config exists
+ls .pi/model-router.json 2>/dev/null && echo "✓ model-router.json" || echo "✗ model-router.json — see .pi/npm/node_modules/@yeliu84/pi-model-router/model-router.example.json"
+```
+
+Do NOT block. If config exists, continue. If missing, warn in report and continue.
+
+**Router activation happens automatically** — the agent should output the following as its next message (this activates the router in the current session):
+
+> `/router profile auto`
+
+The pi TUI will intercept this and activate the `auto` profile. Then continue to Step 4.
 
 ## Step 4 — Configuration Files
 
@@ -374,6 +395,10 @@ cd .pi/npm && npm ls 2>/dev/null && echo "✓ pi extensions" || echo "✗ pi ext
 ls "$WIKI_PATH/index.md" 2>/dev/null && echo "✓ wiki vault" || echo "✗ wiki vault"
 ls "$WIKI_PATH/hot.md" 2>/dev/null && echo "✓ wiki hot cache" || echo "✗ wiki hot cache"
 
+# model router
+ls .pi/npm/node_modules/@yeliu84/pi-model-router/package.json 2>/dev/null && echo "✓ model-router package" || echo "✗ model-router package"
+ls .pi/model-router.json 2>/dev/null && echo "✓ model-router config" || echo "✗ model-router config"
+
 # settings persistence
 grep -q 'wiki_path' .pi/settings.json 2>/dev/null && echo "✓ wiki path saved to settings" || echo "! wiki path not saved"
 
@@ -431,7 +456,8 @@ Output summary table:
 | fallow | ✓/✗ | Baseline: created/pending |
 | biome | ✓/✗ | Project config: found/default |
 | gh CLI | ✓/✗ | Auth: yes/no |
-| pi extensions | ✓/✗ | 3 packages |
+| pi extensions | ✓/✗ | 4 packages |
+| model router | ✓/✗ | Package + config verified, activation via `/router profile auto` |
 
 | .gitignore | ✓/✗ | 6 entries added |
 | wiki_path in settings | ✓/✗ | Persisted to .pi/settings.json |

--- a/.pi/settings.json
+++ b/.pi/settings.json
@@ -1,3 +1,3 @@
 {
-	"packages": ["..", "npm:@posthog/pi", "npm:pi-lean-ctx", "npm:@tintinweb/pi-subagents"]
+	"packages": ["..", "npm:@posthog/pi", "npm:pi-lean-ctx", "npm:@tintinweb/pi-subagents", "npm:@yeliu84/pi-model-router"]
 }


### PR DESCRIPTION
- New model-router.json with auto/cheap/deep tiered routing profiles
- Step 3.5 auto-activates router via /router profile auto (non-blocking)
- Added @yeliu84/pi-model-router to extension packages and verification
- Updated report table with model router status row