### PR TITLE
feat(provider): switch to native Cursor SDK provider

### DIFF
--- a/.pi/harness/browser.json
+++ b/.pi/harness/browser.json
@@ -1,1 +1,0 @@
-{"headless": true, "timeout": 30000, "viewport": {"width": 1280, "height": 720}}

--- a/.pi/model-router.json
+++ b/.pi/model-router.json
@@ -1,95 +1,95 @@
 {
-    "defaultProfile": "auto",
-    "debug": false,
-    "classifierModel": "cursor/gpt-5.3-codex-low-fast",
-    "phaseBias": 0.5,
-    "maxSessionBudget": 1.0,
-    "largeContextThreshold": 100000,
-    "rules": [
-        {
-            "matches": [
-                "deploy",
-                "production",
-                "release"
-            ],
-            "tier": "high",
-            "reason": "Safety check for production tasks"
-        },
-        {
-            "matches": "changelog",
-            "tier": "low"
-        }
-    ],
-    "profiles": {
-        "auto": {
-            "high": {
-                "model": "cursor/gpt-5.3-codex-high-fast",
-                "thinking": "high",
-                "fallbacks": [
-                    "cursor/claude-opus-4-7-thinking-high",
-                    "cursor/gpt-5.5-high"
-                ]
-            },
-            "medium": {
-                "model": "cursor/gpt-5.3-codex-fast",
-                "thinking": "medium",
-                "fallbacks": [
-                    "cursor/claude-4.6-sonnet-medium"
-                ]
-            },
-            "low": {
-                "model": "cursor/gpt-5.3-codex-low-fast",
-                "thinking": "low",
-                "fallbacks": [
-                    "cursor/gpt-5.4-mini-low"
-                ]
-            }
-        },
-        "cheap": {
-            "high": {
-                "model": "cursor/gpt-5.2-codex-high-fast",
-                "thinking": "low",
-                "fallbacks": [
-                    "cursor/gpt-5.4-mini-low"
-                ]
-            },
-            "medium": {
-                "model": "cursor/gpt-5.2-codex-fast",
-                "thinking": "off",
-                "fallbacks": [
-                    "cursor/claude-4.5-sonnet"
-                ]
-            },
-            "low": {
-                "model": "cursor/gpt-5.2-codex-low-fast",
-                "thinking": "off",
-                "fallbacks": [
-                    "cursor/claude-4.5-sonnet"
-                ]
-            }
-        },
-        "deep": {
-            "high": {
-                "model": "cursor/gpt-5.3-codex-xhigh-fast",
-                "thinking": "xhigh",
-                "fallbacks": [
-                    "cursor/claude-opus-4-7-thinking-xhigh"
-                ]
-            },
-            "medium": {
-                "model": "cursor/claude-4.6-sonnet-medium-thinking",
-                "thinking": "medium",
-                "fallbacks": [
-                    "cursor/claude-4.6-sonnet-medium"
-                ]
-            },
-            "low": {
-                "model": "cursor/gpt-5.3-codex-spark-preview-low",
-                "thinking": "low",
-                "fallbacks": [
-                    "cursor/gpt-5.4-medium"
-                ]
-            }
-        }
+  "defaultProfile": "auto",
+  "debug": false,
+  "classifierModel": "cursor/gpt-5.3-codex",
+  "phaseBias": 0.5,
+  "maxSessionBudget": 1.0,
+  "largeContextThreshold": 100000,
+  "rules": [
+    {
+      "matches": [
+        "deploy",
+        "production",
+        "release"
+      ],
+      "tier": "high",
+      "reason": "Safety check for production tasks"
+    },
+    {
+      "matches": "changelog",
+      "tier": "low"
     }
+  ],
+  "profiles": {
+    "auto": {
+      "high": {
+        "model": "cursor/gpt-5.3-codex",
+        "thinking": "high",
+        "fallbacks": [
+          "cursor/claude-opus-4-6",
+          "cursor/gpt-5.2-codex"
+        ]
+      },
+      "medium": {
+        "model": "cursor/gpt-5.3-codex",
+        "thinking": "medium",
+        "fallbacks": [
+          "cursor/claude-sonnet-4-6"
+        ]
+      },
+      "low": {
+        "model": "cursor/gpt-5.2-codex",
+        "thinking": "low",
+        "fallbacks": [
+          "cursor/gpt-5.2"
+        ]
+      }
+    },
+    "cheap": {
+      "high": {
+        "model": "cursor/gpt-5.2-codex",
+        "thinking": "low",
+        "fallbacks": [
+          "cursor/gpt-5.2"
+        ]
+      },
+      "medium": {
+        "model": "cursor/gpt-5.2",
+        "thinking": "off",
+        "fallbacks": [
+          "cursor/claude-sonnet-4-5"
+        ]
+      },
+      "low": {
+        "model": "cursor/gpt-5.1",
+        "thinking": "off",
+        "fallbacks": [
+          "cursor/claude-sonnet-4-5"
+        ]
+      }
+    },
+    "deep": {
+      "high": {
+        "model": "cursor/gpt-5.3-codex",
+        "thinking": "xhigh",
+        "fallbacks": [
+          "cursor/claude-opus-4-6"
+        ]
+      },
+      "medium": {
+        "model": "cursor/claude-sonnet-4-6",
+        "thinking": "medium",
+        "fallbacks": [
+          "cursor/gpt-5.3-codex"
+        ]
+      },
+      "low": {
+        "model": "cursor/gpt-5.2-codex",
+        "thinking": "low",
+        "fallbacks": [
+          "cursor/gpt-5.2"
+        ]
+      }
+    }
+  }
 }

--- a/.pi/providers/cursor-sdk-provider.ts
+++ b/.pi/providers/cursor-sdk-provider.ts
@@ -1,0 +1,609 @@
+import { Agent, type ModelSelection } from "@cursor/sdk";
+import {
+	calculateCost,
+	createAssistantMessageEventStream,
+	type Api,
+	type AssistantMessage,
+	type AssistantMessageEventStream,
+	type Context,
+	type ImageContent,
+	type Model,
+	type SimpleStreamOptions,
+	type TextContent,
+	type Tool,
+} from "@mariozechner/pi-ai";
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+
+type ReasoningLevel = "minimal" | "low" | "medium" | "high" | "xhigh";
+
+type ModelVariants = {
+	default: string;
+	minimal?: string;
+	low?: string;
+	medium?: string;
+	high?: string;
+	xhigh?: string;
+};
+
+const MODEL_MAP: Record<string, ModelVariants> = {
+	"claude-sonnet-4-5": {
+		default: "sonnet-4.5",
+		minimal: "sonnet-4.5-thinking",
+		low: "sonnet-4.5-thinking",
+		medium: "sonnet-4.5-thinking",
+		high: "sonnet-4.5-thinking",
+		xhigh: "sonnet-4.5-thinking",
+	},
+	"claude-sonnet-4-6": {
+		default: "sonnet-4.6",
+		minimal: "sonnet-4.6-thinking",
+		low: "sonnet-4.6-thinking",
+		medium: "sonnet-4.6-thinking",
+		high: "sonnet-4.6-thinking",
+		xhigh: "sonnet-4.6-thinking",
+	},
+	"claude-opus-4-5": {
+		default: "opus-4.5",
+		minimal: "opus-4.5-thinking",
+		low: "opus-4.5-thinking",
+		medium: "opus-4.5-thinking",
+		high: "opus-4.5-thinking",
+		xhigh: "opus-4.5-thinking",
+	},
+	"claude-opus-4-6": {
+		default: "opus-4.6",
+		minimal: "opus-4.6-thinking",
+		low: "opus-4.6-thinking",
+		medium: "opus-4.6-thinking",
+		high: "opus-4.6-thinking",
+		xhigh: "opus-4.6-thinking",
+	},
+	"gpt-5.2": {
+		default: "gpt-5.2",
+		high: "gpt-5.2-high",
+		xhigh: "gpt-5.2-high",
+	},
+	"gpt-5.2-codex": {
+		default: "gpt-5.2-codex",
+		minimal: "gpt-5.2-codex-low",
+		low: "gpt-5.2-codex-low",
+		high: "gpt-5.2-codex-high",
+		xhigh: "gpt-5.2-codex-xhigh",
+	},
+	"gpt-5.3-codex": {
+		default: "gpt-5.3-codex",
+		minimal: "gpt-5.3-codex-low",
+		low: "gpt-5.3-codex-low",
+		high: "gpt-5.3-codex-high",
+		xhigh: "gpt-5.3-codex-xhigh",
+	},
+	"gpt-5.1": { default: "gpt-5.1-high" },
+	"gpt-5.1-codex-max": {
+		default: "gpt-5.1-codex-max",
+		high: "gpt-5.1-codex-max-high",
+		xhigh: "gpt-5.1-codex-max-high",
+	},
+	"gemini-3-pro-preview": { default: "gemini-3-pro" },
+	"gemini-3-flash-preview": { default: "gemini-3-flash" },
+	"grok-code-fast-1": { default: "grok" },
+};
+
+const PROVIDER_MODELS = [
+	{ id: "auto", name: "Auto (Cursor)", reasoning: false, contextWindow: 200000, maxTokens: 32768 },
+	{ id: "claude-sonnet-4-5", name: "Claude 4.5 Sonnet (Cursor)", reasoning: true, contextWindow: 200000, maxTokens: 32000 },
+	{ id: "claude-sonnet-4-6", name: "Claude 4.6 Sonnet (Cursor)", reasoning: true, contextWindow: 200000, maxTokens: 32000 },
+	{ id: "claude-opus-4-5", name: "Claude 4.5 Opus (Cursor)", reasoning: true, contextWindow: 200000, maxTokens: 32000 },
+	{ id: "claude-opus-4-6", name: "Claude 4.6 Opus (Cursor)", reasoning: true, contextWindow: 200000, maxTokens: 32000 },
+	{ id: "gpt-5.1", name: "GPT-5.1 (Cursor)", reasoning: false, contextWindow: 200000, maxTokens: 32768 },
+	{ id: "gpt-5.1-codex-max", name: "GPT-5.1 Codex Max (Cursor)", reasoning: true, contextWindow: 200000, maxTokens: 32768 },
+	{ id: "gpt-5.2", name: "GPT-5.2 (Cursor)", reasoning: true, contextWindow: 200000, maxTokens: 32768 },
+	{ id: "gpt-5.2-codex", name: "GPT-5.2 Codex (Cursor)", reasoning: true, contextWindow: 200000, maxTokens: 32768 },
+	{ id: "gpt-5.3-codex", name: "GPT-5.3 Codex (Cursor)", reasoning: true, contextWindow: 200000, maxTokens: 32768 },
+	{ id: "gemini-3-pro-preview", name: "Gemini 3 Pro (Cursor)", reasoning: false, contextWindow: 1000000, maxTokens: 65536 },
+	{ id: "gemini-3-flash-preview", name: "Gemini 3 Flash (Cursor)", reasoning: false, contextWindow: 1000000, maxTokens: 65536 },
+	{ id: "grok-code-fast-1", name: "Grok (Cursor)", reasoning: false, contextWindow: 131072, maxTokens: 32768 },
+	{ id: "composer-1", name: "Composer 1 (Cursor)", reasoning: false, contextWindow: 200000, maxTokens: 32768 },
+	{ id: "composer-1.5", name: "Composer 1.5 (Cursor)", reasoning: false, contextWindow: 200000, maxTokens: 32768 },
+];
+
+function toCursorModelId(canonicalId: string, reasoning?: string): string {
+	const family = MODEL_MAP[canonicalId];
+	if (!family) {
+		return canonicalId;
+	}
+	const level = reasoning as ReasoningLevel | undefined;
+	const variant = level ? family[level] : undefined;
+	return variant ?? family.default;
+}
+
+function contentBlockToText(block: TextContent | ImageContent): string {
+	if (block.type === "text") {
+		return block.text;
+	}
+	const bytes = Math.round((block.data.length * 3) / 4);
+	return `[Image: ${block.mimeType}, ~${bytes} bytes]`;
+}
+
+function formatTools(tools: Tool[] | undefined): string {
+	if (!tools || tools.length === 0) {
+		return "";
+	}
+
+	const lines = ["[Available Pi Tools]"];
+	for (const tool of tools) {
+		lines.push(`- ${tool.name}: ${tool.description}`);
+		lines.push(`  schema: ${JSON.stringify(tool.parameters)}`);
+	}
+	lines.push(
+		"When tool needed, reply ONLY with fenced block:",
+		"```pi_tool_call",
+		'{"name":"tool_name","arguments":{}}',
+		"```",
+		"No extra text before/after fence when calling tool.",
+		"Never use emoji.",
+		"Never add markdown decoration unless explicitly requested.",
+	);
+
+	return lines.join("\n");
+}
+
+function serializeContext(context: Context): string {
+	const lines: string[] = [];
+
+	if (context.systemPrompt) {
+		lines.push(`[System]\n${context.systemPrompt}`);
+	}
+
+	const toolsSection = formatTools(context.tools);
+	if (toolsSection) {
+		lines.push(toolsSection);
+	}
+
+	for (const msg of context.messages) {
+		if (msg.role === "user") {
+			const text = typeof msg.content === "string" ? msg.content : msg.content.map(contentBlockToText).join("\n");
+			lines.push(`[User]\n${text}`);
+			continue;
+		}
+
+		if (msg.role === "assistant") {
+			const text = msg.content
+				.filter((c): c is TextContent => c.type === "text")
+				.map((c) => c.text)
+				.join("\n");
+			if (text.trim().length > 0) {
+				lines.push(`[Assistant]\n${text}`);
+			}
+			continue;
+		}
+
+		const text = msg.content.map(contentBlockToText).join("\n");
+		if (text.trim().length > 0) {
+			lines.push(`[Tool result: ${msg.toolName}]\n${text}`);
+		}
+	}
+
+	return lines.join("\n\n");
+}
+
+function estimateTokens(text: string): number {
+	if (!text) return 0;
+	return Math.max(1, Math.ceil(text.length / 4));
+}
+
+function applyUsage(model: Model<Api>, output: AssistantMessage, promptText: string, finalText: string): void {
+	output.usage.input = estimateTokens(promptText);
+	output.usage.output = estimateTokens(finalText);
+	output.usage.cacheRead = 0;
+	output.usage.cacheWrite = 0;
+	output.usage.totalTokens = output.usage.input + output.usage.output;
+	output.usage.cost = calculateCost(model, output.usage);
+}
+
+function parsePiToolCall(text: string, context: Context): { name: string; arguments: Record<string, unknown> } | undefined {
+	if (!context.tools || context.tools.length === 0) {
+		return undefined;
+	}
+
+	const fenced = text.match(/```pi_tool_call\s*([\s\S]*?)```/i)?.[1]?.trim();
+	const candidates = [fenced, text.trim()].filter((v): v is string => Boolean(v));
+
+	for (const candidate of candidates) {
+		try {
+			const parsed = JSON.parse(candidate) as { name?: unknown; arguments?: unknown };
+			if (typeof parsed.name !== "string") {
+				continue;
+			}
+			if (!context.tools.some((t) => t.name === parsed.name)) {
+				continue;
+			}
+			const args = parsed.arguments;
+			if (!args || typeof args !== "object" || Array.isArray(args)) {
+				return { name: parsed.name, arguments: {} };
+			}
+			return { name: parsed.name, arguments: args as Record<string, unknown> };
+		} catch {
+			// try next candidate
+		}
+	}
+	return undefined;
+}
+
+function parseBracketToolCall(text: string, context: Context): { name: string; arguments: Record<string, unknown> } | undefined {
+	if (!context.tools || context.tools.length === 0) {
+		return undefined;
+	}
+
+	const extractBalancedJson = (input: string): string | undefined => {
+		const start = input.indexOf("{");
+		if (start === -1) return undefined;
+		let depth = 0;
+		let inString = false;
+		let escaped = false;
+		for (let i = start; i < input.length; i++) {
+			const ch = input[i];
+			if (inString) {
+				if (escaped) {
+					escaped = false;
+					continue;
+				}
+				if (ch === "\\") {
+					escaped = true;
+					continue;
+				}
+				if (ch === "\"") {
+					inString = false;
+				}
+				continue;
+			}
+			if (ch === "\"") {
+				inString = true;
+				continue;
+			}
+			if (ch === "{") {
+				depth++;
+				continue;
+			}
+			if (ch === "}") {
+				depth--;
+				if (depth === 0) {
+					return input.slice(start, i + 1);
+				}
+			}
+		}
+		return undefined;
+	};
+
+	const extractBestEffortArgs = (input: string): Record<string, unknown> | undefined => {
+		const args: Record<string, unknown> = {};
+
+		const command = input.match(/"command"\s*:\s*"([^"\n\r]*)/);
+		if (command?.[1]) args.command = command[1];
+
+		const workingDirectory = input.match(/"workingDirectory"\s*:\s*"([^"\n\r]*)/);
+		if (workingDirectory?.[1] !== undefined) args.workingDirectory = workingDirectory[1];
+
+		const path = input.match(/"path"\s*:\s*"([^"\n\r]*)/);
+		if (path?.[1]) args.path = path[1];
+
+		const pattern = input.match(/"pattern"\s*:\s*"([^"\n\r]*)/);
+		if (pattern?.[1]) args.pattern = pattern[1];
+
+		const timeout = input.match(/"timeout"\s*:\s*(\d+)/);
+		if (timeout?.[1]) args.timeout = Number(timeout[1]);
+
+		return Object.keys(args).length > 0 ? args : undefined;
+	};
+
+	const lines = text.split("\n");
+	for (let i = lines.length - 1; i >= 0; i--) {
+		const line = lines[i]?.trim();
+		if (!line) continue;
+		const match = line.match(/^(?:⏳\s*)?\[([^\]]+)\]\s*(.*)$/);
+		if (!match) continue;
+		const [, rawName, inlinePayload] = match;
+		const toolName = context.tools.find((tool) => tool.name.toLowerCase() === rawName.trim().toLowerCase())?.name;
+		if (!toolName) continue;
+
+		const trailingText = lines.slice(i).join("\n");
+		const rawArgs =
+			extractBalancedJson(inlinePayload) ??
+			extractBalancedJson(trailingText);
+		if (!rawArgs) {
+			const fallbackArgs = extractBestEffortArgs(trailingText);
+			if (fallbackArgs) {
+				return { name: toolName, arguments: fallbackArgs };
+			}
+			continue;
+		}
+		try {
+			const args = JSON.parse(rawArgs);
+			if (!args || typeof args !== "object" || Array.isArray(args)) {
+				return { name: toolName, arguments: {} };
+			}
+			return { name: toolName, arguments: args as Record<string, unknown> };
+		} catch {
+			const fallbackArgs = extractBestEffortArgs(trailingText);
+			if (fallbackArgs) {
+				return { name: toolName, arguments: fallbackArgs };
+			}
+		}
+	}
+	return undefined;
+}
+
+function stripToolCallMarkup(text: string): string {
+	return text
+		.replace(/```pi_tool_call\s*[\s\S]*?```/gi, "")
+		.replace(/\{\s*"name"\s*:\s*"[^"]+"\s*,\s*"arguments"\s*:\s*\{[\s\S]*?\}\s*\}/g, "")
+		.replace(/(?:^|\n)\s*(?:⏳\s*)?\[[^\]]+\]\s*\{[\s\S]*?(?=\n(?:\s*(?:Status|Actions)\s*:|$)|$)/g, "")
+		.trim();
+}
+
+function likelyNeedsTool(text: string): boolean {
+	const lower = text.toLowerCase();
+	const signals = ["use ", "run ", "read ", "write ", "edit ", "find ", "grep ", "list ", "ls ", "bash ", "command", "file", "directory", "tool"];
+	return signals.some((s) => lower.includes(s));
+}
+
+function streamCursorSdk(model: Model<Api>, context: Context, options?: SimpleStreamOptions): AssistantMessageEventStream {
+	const stream = createAssistantMessageEventStream();
+
+	const availableTools = context.tools?.map((tool) => tool.name) ?? [];
+	const resolveToolName = (candidates: string[]): string | undefined => {
+		for (const candidate of candidates) {
+			if (availableTools.includes(candidate)) {
+				return candidate;
+			}
+		}
+		for (const candidate of candidates) {
+			const matched = availableTools.find((tool) => tool.toLowerCase() === candidate.toLowerCase());
+			if (matched) {
+				return matched;
+			}
+		}
+		return undefined;
+	};
+
+	const mapCursorTool = (name: string, input: unknown): { name: string; arguments: Record<string, unknown> } | undefined => {
+		const n = name.toLowerCase();
+		const args = typeof input === "object" && input !== null ? (input as Record<string, unknown>) : {};
+		if (n === "read") {
+			const mappedName = resolveToolName(["Read", "read", "ReadFile", "readfile"]);
+			if (!mappedName) return undefined;
+			return { name: mappedName, arguments: { path: args.path ?? "" } };
+		}
+		if (n === "shell" || n === "bash") {
+			const mappedName = resolveToolName(["Shell", "bash", "shell", "Bash"]);
+			if (!mappedName) return undefined;
+			return { name: mappedName, arguments: { command: args.command ?? "" } };
+		}
+		if (n === "ls") {
+			const mappedName = resolveToolName(["LS", "ls", "List"]);
+			if (!mappedName) return undefined;
+			return { name: mappedName, arguments: { path: args.path ?? "." } };
+		}
+		if (n === "grep") {
+			const mappedName = resolveToolName(["Grep", "grep", "Search"]);
+			if (!mappedName) return undefined;
+			return { name: mappedName, arguments: { pattern: args.pattern ?? "", path: args.path ?? "." } };
+		}
+		if (n === "glob" || n === "find") {
+			const mappedName = resolveToolName(["Find", "find"]);
+			if (!mappedName) return undefined;
+			return { name: mappedName, arguments: { pattern: args.globPattern ?? args.pattern ?? "**/*", path: args.targetDirectory ?? "." } };
+		}
+		if (n === "write") {
+			const mappedName = resolveToolName(["Write", "write"]);
+			if (!mappedName) return undefined;
+			return { name: mappedName, arguments: { path: args.path ?? "", content: args.fileText ?? "" } };
+		}
+		const passthrough = resolveToolName([name, n]);
+		if (!passthrough) return undefined;
+		return { name: passthrough, arguments: args };
+	};
+
+	const emitToolCallBlock = (output: AssistantMessage, mapped: { name: string; arguments: Record<string, unknown> }, id?: string): void => {
+		const contentIndex = output.content.length;
+		const toolCallId = id || `call_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`;
+		const piToolCall = {
+			type: "toolCall" as const,
+			id: toolCallId,
+			name: mapped.name,
+			arguments: mapped.arguments,
+		};
+		output.content.push(piToolCall);
+		stream.push({ type: "toolcall_start", contentIndex, partial: output });
+		stream.push({
+			type: "toolcall_delta",
+			contentIndex,
+			delta: JSON.stringify(mapped.arguments),
+			partial: output,
+		});
+		stream.push({ type: "toolcall_end", contentIndex, toolCall: piToolCall, partial: output });
+	};
+
+	(async () => {
+		let runCancel: (() => Promise<void>) | undefined;
+		let aborted = false;
+		let sawPiToolCall = false;
+		let plainText = "";
+		const emittedToolCallIds = new Set<string>();
+
+		const output: AssistantMessage = {
+			role: "assistant",
+			content: [],
+			api: model.api,
+			provider: model.provider,
+			model: model.id,
+			usage: {
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 0,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "stop",
+			timestamp: Date.now(),
+		};
+
+		const onAbort = () => {
+			aborted = true;
+			void runCancel?.();
+		};
+
+		try {
+			stream.push({ type: "start", partial: output });
+
+			const selectedModel = toCursorModelId(model.id, options?.reasoning);
+			const promptText = serializeContext(context);
+			const agent = await Agent.create({
+				apiKey: process.env.CURSOR_API_KEY,
+				model: { id: selectedModel } as ModelSelection,
+				local: { cwd: process.cwd() },
+			});
+
+			try {
+				options?.signal?.addEventListener("abort", onAbort, { once: true });
+				const run = await agent.send(promptText, { local: { force: true } });
+				runCancel = () => run.cancel();
+
+				for await (const event of run.stream()) {
+					if (aborted) break;
+					if (event.type === "tool_call") {
+						if (event.status !== "running" && event.status !== "completed") {
+							continue;
+						}
+						if (emittedToolCallIds.has(event.call_id)) {
+							continue;
+						}
+						const mapped = mapCursorTool(event.name, event.args);
+						if (!mapped) continue;
+						emittedToolCallIds.add(event.call_id);
+						emitToolCallBlock(output, mapped, event.call_id);
+						sawPiToolCall = true;
+						continue;
+					}
+					if (event.type !== "assistant") continue;
+
+					for (const block of event.message.content) {
+						if (block.type === "text") {
+							const text = block.text || "";
+							if (!text) continue;
+							plainText += text;
+							const idx = output.content.length;
+							output.content.push({ type: "text", text: "" });
+							stream.push({ type: "text_start", contentIndex: idx, partial: output });
+							(output.content[idx] as TextContent).text = text;
+							stream.push({ type: "text_delta", contentIndex: idx, delta: text, partial: output });
+							stream.push({ type: "text_end", contentIndex: idx, content: text, partial: output });
+							continue;
+						}
+
+						if (block.type === "tool_use") {
+							const mapped = mapCursorTool(block.name, block.input);
+							if (!mapped) continue;
+							const toolCallId = block.id || `call_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`;
+							if (emittedToolCallIds.has(toolCallId)) {
+								continue;
+							}
+							emittedToolCallIds.add(toolCallId);
+							emitToolCallBlock(output, mapped, toolCallId);
+							sawPiToolCall = true;
+						}
+					}
+				}
+
+				const result = await run.wait();
+				if (aborted || options?.signal?.aborted || result.status === "cancelled") {
+					output.stopReason = "aborted";
+					output.errorMessage = "Request aborted";
+					stream.push({ type: "error", reason: "aborted", error: output });
+					stream.end();
+					return;
+				}
+				if (result.status !== "finished") {
+					output.stopReason = "error";
+					output.errorMessage = result.result || `Cursor SDK run status: ${result.status}`;
+					stream.push({ type: "error", reason: "error", error: output });
+					stream.end();
+					return;
+				}
+
+				applyUsage(model, output, promptText, plainText || result.result || "");
+
+				// Some models may output fenced `pi_tool_call` JSON as plain text instead of native tool blocks.
+				// Convert it into a real toolCall block so Pi UI/tool execution works consistently.
+				if (!sawPiToolCall) {
+					const parsedPiToolCall = parsePiToolCall(plainText, context) ?? parseBracketToolCall(plainText, context);
+					if (parsedPiToolCall) {
+						const contentIndex = output.content.length;
+						const toolCallId = `call_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`;
+						const piToolCall = {
+							type: "toolCall" as const,
+							id: toolCallId,
+							name: parsedPiToolCall.name,
+							arguments: parsedPiToolCall.arguments,
+						};
+						output.content.push(piToolCall);
+						stream.push({ type: "toolcall_start", contentIndex, partial: output });
+						stream.push({
+							type: "toolcall_delta",
+							contentIndex,
+							delta: JSON.stringify(parsedPiToolCall.arguments),
+							partial: output,
+						});
+						stream.push({ type: "toolcall_end", contentIndex, toolCall: piToolCall, partial: output });
+						sawPiToolCall = true;
+
+						const cleaned = stripToolCallMarkup(plainText);
+						if (cleaned !== plainText) {
+							for (const content of output.content) {
+								if (content.type === "text") {
+									content.text = stripToolCallMarkup(content.text);
+								}
+							}
+						}
+					}
+				}
+
+				if (sawPiToolCall) {
+					output.stopReason = "toolUse";
+					stream.push({ type: "done", reason: "toolUse", message: output });
+				} else {
+					stream.push({ type: "done", reason: "stop", message: output });
+				}
+				stream.end();
+			} finally {
+				options?.signal?.removeEventListener("abort", onAbort);
+				agent.close();
+			}
+		} catch (error) {
+			output.stopReason = options?.signal?.aborted ? "aborted" : "error";
+			output.errorMessage = error instanceof Error ? error.message : String(error);
+			stream.push({ type: "error", reason: output.stopReason, error: output });
+			stream.end();
+		}
+	})();
+
+	return stream;
+}
+
+export default function cursorSdkProvider(pi: ExtensionAPI) {
+	pi.registerProvider("cursor", {
+		baseUrl: "cursor://sdk",
+		apiKey: "CURSOR_API_KEY",
+		api: "cursor-sdk" as Api,
+		models: PROVIDER_MODELS.map((model) => ({
+			id: model.id,
+			name: model.name,
+			reasoning: model.reasoning,
+			input: ["text"] as ("text" | "image")[],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: model.contextWindow,
+			maxTokens: model.maxTokens,
+		})),
+		streamSimple: streamCursorSdk,
+	});
+}

--- a/.pi/settings.json
+++ b/.pi/settings.json
@@ -1,9 +1,15 @@
 {
 	"defaultProvider": "router",
 	"defaultModel": "auto",
-	  "retry": {
-    "enabled": true,
-    "maxRetries": 3
-  },
-	"packages": ["..", "npm:@posthog/pi", "npm:pi-lean-ctx", "npm:@tintinweb/pi-subagents", "npm:@yeliu84/pi-model-router", "npm:@netandreus/pi-cursor-provider"]
+	"retry": {
+		"enabled": true,
+		"maxRetries": 3
+	},
+	"packages": [
+		"..",
+		"npm:@posthog/pi",
+		"npm:pi-lean-ctx",
+		"npm:@tintinweb/pi-subagents",
+		"npm:@yeliu84/pi-model-router"
+	]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
 			"version": "0.1.2",
 			"license": "MIT",
 			"dependencies": {
+				"@cursor/sdk": "^1.0.12",
 				"asciify-image": "^0.1.10"
 			},
 			"devDependencies": {
@@ -1048,6 +1049,163 @@
 				"url": "https://github.com/sponsors/Borewit"
 			}
 		},
+		"node_modules/@bufbuild/protobuf": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-1.10.0.tgz",
+			"integrity": "sha512-QDdVFLoN93Zjg36NoQPZfsVH9tZew7wKDKyV5qRdj8ntT4wQCOradQjRaTdwMhWUYsgKsvCINKKm87FdEk96Ag==",
+			"license": "(Apache-2.0 AND BSD-3-Clause)"
+		},
+		"node_modules/@connectrpc/connect": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-1.7.0.tgz",
+			"integrity": "sha512-iNKdJRi69YP3mq6AePRT8F/HrxWCewrhxnLMNm0vpqXAR8biwzRtO6Hjx80C6UvtKJ5sFmffQT7I4Baecz389w==",
+			"license": "Apache-2.0",
+			"peerDependencies": {
+				"@bufbuild/protobuf": "^1.10.0"
+			}
+		},
+		"node_modules/@connectrpc/connect-node": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/@connectrpc/connect-node/-/connect-node-1.7.0.tgz",
+			"integrity": "sha512-6vaPIkG/NyhxlYgytLoR9KYbPhczEboFB2OYWkA9qvUz1K7efXfeGrlRxoLtpa+r8VxyIOw73w5ktNe743nD+A==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"undici": "^5.28.4"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			},
+			"peerDependencies": {
+				"@bufbuild/protobuf": "^1.10.0",
+				"@connectrpc/connect": "1.7.0"
+			}
+		},
+		"node_modules/@connectrpc/connect-node/node_modules/undici": {
+			"version": "5.29.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+			"integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+			"license": "MIT",
+			"dependencies": {
+				"@fastify/busboy": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=14.0"
+			}
+		},
+		"node_modules/@cursor/sdk": {
+			"version": "1.0.12",
+			"resolved": "https://registry.npmjs.org/@cursor/sdk/-/sdk-1.0.12.tgz",
+			"integrity": "sha512-jGx0wFY1N9uIdIKr303CfM6m/dLXmRCUnU/0yNP/oiOpkBXqgqaThGbgYbcOeVrYonMZc/DZJ9EydXOEPJLcbg==",
+			"license": "SEE LICENSE IN LICENSE.md",
+			"dependencies": {
+				"@bufbuild/protobuf": "1.10.0",
+				"@connectrpc/connect": "^1.6.1",
+				"@connectrpc/connect-node": "^1.6.1",
+				"@statsig/js-client": "3.31.0",
+				"sqlite3": "^5.1.7",
+				"zod": "^3.25.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"optionalDependencies": {
+				"@cursor/sdk-darwin-arm64": "1.0.12",
+				"@cursor/sdk-darwin-x64": "1.0.12",
+				"@cursor/sdk-linux-arm64": "1.0.12",
+				"@cursor/sdk-linux-x64": "1.0.12",
+				"@cursor/sdk-win32-x64": "1.0.12"
+			}
+		},
+		"node_modules/@cursor/sdk-darwin-arm64": {
+			"version": "1.0.12",
+			"resolved": "https://registry.npmjs.org/@cursor/sdk-darwin-arm64/-/sdk-darwin-arm64-1.0.12.tgz",
+			"integrity": "sha512-AOFx+aX+4SntAeC66YncHACXk5duxp+HzDrxxF4Tl93N6nLjHaHEKSAXbt87ivL34MCHop4v/3c70QzBhamB2g==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "SEE LICENSE IN LICENSE.md",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@cursor/sdk-darwin-x64": {
+			"version": "1.0.12",
+			"resolved": "https://registry.npmjs.org/@cursor/sdk-darwin-x64/-/sdk-darwin-x64-1.0.12.tgz",
+			"integrity": "sha512-/ZDAYFUrnPd8hAGRky9ZGcROqZSZ2b5W+aEjTdINzLhJ8x5ZNXtjaz0ZYSHabOn2BeErjXgTcq+4bX2/To4C1A==",
+			"cpu": [
+				"x64"
+			],
+			"license": "SEE LICENSE IN LICENSE.md",
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/@cursor/sdk-linux-arm64": {
+			"version": "1.0.12",
+			"resolved": "https://registry.npmjs.org/@cursor/sdk-linux-arm64/-/sdk-linux-arm64-1.0.12.tgz",
+			"integrity": "sha512-kAxNqiB3dPtlW9fVjjIZEdbIGEGLA9moOM3zYwsXh8J1Qw942nJYMGDGR4o8x0zglwZ24a1JpovvZamrCaC3Yw==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "SEE LICENSE IN LICENSE.md",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@cursor/sdk-linux-x64": {
+			"version": "1.0.12",
+			"resolved": "https://registry.npmjs.org/@cursor/sdk-linux-x64/-/sdk-linux-x64-1.0.12.tgz",
+			"integrity": "sha512-RmBiBCPKMZC5McDerGk2Rk4P47xz2A+uzRoRgH6sMoOjklc33ry11iAZC0D5F5xH85chgY878086A/Q8+XrAuA==",
+			"cpu": [
+				"x64"
+			],
+			"license": "SEE LICENSE IN LICENSE.md",
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/@cursor/sdk-win32-x64": {
+			"version": "1.0.12",
+			"resolved": "https://registry.npmjs.org/@cursor/sdk-win32-x64/-/sdk-win32-x64-1.0.12.tgz",
+			"integrity": "sha512-uH4shdHrKOdtNLapy1uuScJ9lL2Pc8zc9I9ZKC6b6bx+0UX6xLAqjPP7dqVPfO6D9u61yLq1Hs86XOLs5ZVkPA==",
+			"cpu": [
+				"x64"
+			],
+			"license": "SEE LICENSE IN LICENSE.md",
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/@cursor/sdk/node_modules/zod": {
+			"version": "3.25.76",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+			"integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/colinhacks"
+			}
+		},
+		"node_modules/@fastify/busboy": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+			"integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"node_modules/@gar/promisify": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
+			"integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==",
+			"license": "MIT",
+			"optional": true
+		},
 		"node_modules/@google/genai": {
 			"version": "1.50.1",
 			"resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.50.1.tgz",
@@ -1885,6 +2043,32 @@
 			],
 			"license": "MIT"
 		},
+		"node_modules/@npmcli/fs": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-1.1.1.tgz",
+			"integrity": "sha512-8KG5RD0GVP4ydEzRn/I4BNDuxDtqVbOdm8675T49OIG/NGhaK0pjPX7ZcDlvKYbA+ulvVK3ztfcF4uBdOxuJbQ==",
+			"license": "ISC",
+			"optional": true,
+			"dependencies": {
+				"@gar/promisify": "^1.0.1",
+				"semver": "^7.3.5"
+			}
+		},
+		"node_modules/@npmcli/move-file": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-1.1.2.tgz",
+			"integrity": "sha512-1SUf/Cg2GzGDyaf15aR9St9TWlb+XvbZXWpDx8YKs7MLzMH/BCeopv+y9vzrzgkfykCGuWOlSu3mZhj2+FQcrg==",
+			"deprecated": "This functionality has been moved to @npmcli/fs",
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"mkdirp": "^1.0.4",
+				"rimraf": "^3.0.2"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/@protobufjs/aspromise": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
@@ -2655,6 +2839,21 @@
 				"node": ">=18.0.0"
 			}
 		},
+		"node_modules/@statsig/client-core": {
+			"version": "3.31.0",
+			"resolved": "https://registry.npmjs.org/@statsig/client-core/-/client-core-3.31.0.tgz",
+			"integrity": "sha512-SuxQD6TmVszPG7FoMKwTk/uyBuVFk7XnxI3T/E0uyb7PL7GNjONtfsoh+NqBBVUJVse0CUeSFfgJPoZy1ZOslQ==",
+			"license": "ISC"
+		},
+		"node_modules/@statsig/js-client": {
+			"version": "3.31.0",
+			"resolved": "https://registry.npmjs.org/@statsig/js-client/-/js-client-3.31.0.tgz",
+			"integrity": "sha512-LFa5E0LjT6sTfZv3sNGoyRLSZ1078+agdgOA+Vm1ecjG+KbSOfBLTW7hMwimrJ29slRwbYDzbtKaPJo/R37N2g==",
+			"license": "ISC",
+			"dependencies": {
+				"@statsig/client-core": "3.31.0"
+			}
+		},
 		"node_modules/@tokenizer/inflate": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.4.1.tgz",
@@ -2678,6 +2877,16 @@
 			"resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
 			"integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
 			"license": "MIT"
+		},
+		"node_modules/@tootallnate/once": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
+			"integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">= 6"
+			}
 		},
 		"node_modules/@tootallnate/quickjs-emscripten": {
 			"version": "0.23.0",
@@ -2721,6 +2930,13 @@
 				"@types/node": "*"
 			}
 		},
+		"node_modules/abbrev": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+			"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+			"license": "ISC",
+			"optional": true
+		},
 		"node_modules/abort-controller": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -2741,6 +2957,33 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 14"
+			}
+		},
+		"node_modules/agentkeepalive": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
+			"integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"humanize-ms": "^1.2.1"
+			},
+			"engines": {
+				"node": ">= 8.0.0"
+			}
+		},
+		"node_modules/aggregate-error": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+			"integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"clean-stack": "^2.0.0",
+				"indent-string": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/ajv": {
@@ -2860,6 +3103,43 @@
 			"integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/aproba": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/aproba/-/aproba-2.1.0.tgz",
+			"integrity": "sha512-tLIEcj5GuR2RSTnxNKdkK0dJ/GrC7P38sUkiDmDuHfsHmbagTFAxDVIBltoklXEVIQ/f14IL8IMJ5pn9Hez1Ew==",
+			"license": "ISC",
+			"optional": true
+		},
+		"node_modules/are-we-there-yet": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-3.0.1.tgz",
+			"integrity": "sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg==",
+			"deprecated": "This package is no longer supported.",
+			"license": "ISC",
+			"optional": true,
+			"dependencies": {
+				"delegates": "^1.0.0",
+				"readable-stream": "^3.6.0"
+			},
+			"engines": {
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+			}
+		},
+		"node_modules/are-we-there-yet/node_modules/readable-stream": {
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"inherits": "^2.0.3",
+				"string_decoder": "^1.1.1",
+				"util-deprecate": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
 		},
 		"node_modules/asciify-image": {
 			"version": "0.1.10",
@@ -2989,6 +3269,40 @@
 				"node": "*"
 			}
 		},
+		"node_modules/bindings": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+			"integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+			"license": "MIT",
+			"dependencies": {
+				"file-uri-to-path": "1.0.0"
+			}
+		},
+		"node_modules/bl": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+			"integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+			"license": "MIT",
+			"dependencies": {
+				"buffer": "^5.5.0",
+				"inherits": "^2.0.4",
+				"readable-stream": "^3.4.0"
+			}
+		},
+		"node_modules/bl/node_modules/readable-stream": {
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+			"license": "MIT",
+			"dependencies": {
+				"inherits": "^2.0.3",
+				"string_decoder": "^1.1.1",
+				"util-deprecate": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
 		"node_modules/bmp-js": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/bmp-js/-/bmp-js-0.1.0.tgz",
@@ -3065,6 +3379,115 @@
 			"dev": true,
 			"license": "BSD-3-Clause"
 		},
+		"node_modules/cacache": {
+			"version": "15.3.0",
+			"resolved": "https://registry.npmjs.org/cacache/-/cacache-15.3.0.tgz",
+			"integrity": "sha512-VVdYzXEn+cnbXpFgWs5hTT7OScegHVmLhJIR8Ufqk3iFD6A6j5iSX1KuBTfNEv4tdJWE2PzA6IVFtcLC7fN9wQ==",
+			"license": "ISC",
+			"optional": true,
+			"dependencies": {
+				"@npmcli/fs": "^1.0.0",
+				"@npmcli/move-file": "^1.0.1",
+				"chownr": "^2.0.0",
+				"fs-minipass": "^2.0.0",
+				"glob": "^7.1.4",
+				"infer-owner": "^1.0.4",
+				"lru-cache": "^6.0.0",
+				"minipass": "^3.1.1",
+				"minipass-collect": "^1.0.2",
+				"minipass-flush": "^1.0.5",
+				"minipass-pipeline": "^1.2.2",
+				"mkdirp": "^1.0.3",
+				"p-map": "^4.0.0",
+				"promise-inflight": "^1.0.1",
+				"rimraf": "^3.0.2",
+				"ssri": "^8.0.1",
+				"tar": "^6.0.2",
+				"unique-filename": "^1.1.1"
+			},
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/cacache/node_modules/balanced-match": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+			"license": "MIT",
+			"optional": true
+		},
+		"node_modules/cacache/node_modules/brace-expansion": {
+			"version": "1.1.14",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"node_modules/cacache/node_modules/glob": {
+			"version": "7.2.3",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+			"deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+			"license": "ISC",
+			"optional": true,
+			"dependencies": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.1.1",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
+			},
+			"engines": {
+				"node": "*"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/cacache/node_modules/lru-cache": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+			"license": "ISC",
+			"optional": true,
+			"dependencies": {
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/cacache/node_modules/minimatch": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+			"license": "ISC",
+			"optional": true,
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/cacache/node_modules/minipass": {
+			"version": "3.3.6",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+			"integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+			"license": "ISC",
+			"optional": true,
+			"dependencies": {
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/caseless": {
 			"version": "0.12.0",
 			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
@@ -3091,6 +3514,25 @@
 			},
 			"funding": {
 				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/chownr": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+			"integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+			"license": "ISC",
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/clean-stack": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+			"integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/cli-highlight": {
@@ -3187,6 +3629,16 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/color-support": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+			"integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+			"license": "ISC",
+			"optional": true,
+			"bin": {
+				"color-support": "bin.js"
+			}
+		},
 		"node_modules/combined-stream": {
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -3198,6 +3650,20 @@
 			"engines": {
 				"node": ">= 0.8"
 			}
+		},
+		"node_modules/concat-map": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+			"license": "MIT",
+			"optional": true
+		},
+		"node_modules/console-control-strings": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+			"integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
+			"license": "ISC",
+			"optional": true
 		},
 		"node_modules/core-util-is": {
 			"version": "1.0.2",
@@ -3267,7 +3733,7 @@
 			"version": "4.4.3",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
 			"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"ms": "^2.1.3"
@@ -3279,6 +3745,30 @@
 				"supports-color": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/decompress-response": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+			"integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+			"license": "MIT",
+			"dependencies": {
+				"mimic-response": "^3.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/deep-extend": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+			"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=4.0.0"
 			}
 		},
 		"node_modules/deffy": {
@@ -3326,6 +3816,22 @@
 				"node": ">=0.4.0"
 			}
 		},
+		"node_modules/delegates": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+			"integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
+			"license": "MIT",
+			"optional": true
+		},
+		"node_modules/detect-libc": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+			"integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/diff": {
 			"version": "8.0.4",
 			"resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
@@ -3365,18 +3871,44 @@
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
 			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT"
+		},
+		"node_modules/encoding": {
+			"version": "0.1.13",
+			"resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+			"integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"iconv-lite": "^0.6.2"
+			}
 		},
 		"node_modules/end-of-stream": {
 			"version": "1.4.5",
 			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
 			"integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"once": "^1.4.0"
 			}
+		},
+		"node_modules/env-paths": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+			"integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/err-code": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
+			"integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
+			"license": "MIT",
+			"optional": true
 		},
 		"node_modules/escalade": {
 			"version": "3.2.0",
@@ -3466,6 +3998,15 @@
 			"version": "0.1.12",
 			"resolved": "https://registry.npmjs.org/exif-parser/-/exif-parser-0.1.12.tgz",
 			"integrity": "sha512-c2bQfLNbMzLPmzQuOr8fy0csy84WmwnER81W88DzTp9CYNPJ6yzOj2EZAh9pywYpqHnshVLHQJ8WzldAyfY+Iw=="
+		},
+		"node_modules/expand-template": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+			"integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+			"license": "(MIT OR WTFPL)",
+			"engines": {
+				"node": ">=6"
+			}
 		},
 		"node_modules/extend": {
 			"version": "3.0.2",
@@ -3606,6 +4147,12 @@
 				"url": "https://github.com/sindresorhus/file-type?sponsor=1"
 			}
 		},
+		"node_modules/file-uri-to-path": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+			"integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+			"license": "MIT"
+		},
 		"node_modules/follow-redirects": {
 			"version": "1.16.0",
 			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
@@ -3683,6 +4230,43 @@
 				"node": ">=12.20.0"
 			}
 		},
+		"node_modules/fs-constants": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+			"integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+			"license": "MIT"
+		},
+		"node_modules/fs-minipass": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+			"integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+			"license": "ISC",
+			"dependencies": {
+				"minipass": "^3.0.0"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/fs-minipass/node_modules/minipass": {
+			"version": "3.3.6",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+			"integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+			"license": "ISC",
+			"dependencies": {
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/fs.realpath": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+			"license": "ISC",
+			"optional": true
+		},
 		"node_modules/function-bind": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -3699,6 +4283,50 @@
 			"license": "MIT",
 			"dependencies": {
 				"noop6": "^1.0.1"
+			}
+		},
+		"node_modules/gauge": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/gauge/-/gauge-4.0.4.tgz",
+			"integrity": "sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==",
+			"deprecated": "This package is no longer supported.",
+			"license": "ISC",
+			"optional": true,
+			"dependencies": {
+				"aproba": "^1.0.3 || ^2.0.0",
+				"color-support": "^1.1.3",
+				"console-control-strings": "^1.1.0",
+				"has-unicode": "^2.0.1",
+				"signal-exit": "^3.0.7",
+				"string-width": "^4.2.3",
+				"strip-ansi": "^6.0.1",
+				"wide-align": "^1.1.5"
+			},
+			"engines": {
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+			}
+		},
+		"node_modules/gauge/node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/gauge/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/gaxios": {
@@ -3814,6 +4442,12 @@
 				"omggif": "^1.0.10"
 			}
 		},
+		"node_modules/github-from-package": {
+			"version": "0.0.0",
+			"resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+			"integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+			"license": "MIT"
+		},
 		"node_modules/glob": {
 			"version": "13.0.6",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
@@ -3874,7 +4508,7 @@
 			"version": "4.2.11",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
 			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-			"dev": true,
+			"devOptional": true,
 			"license": "ISC"
 		},
 		"node_modules/har-schema": {
@@ -3910,6 +4544,13 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/has-unicode": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+			"integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
+			"license": "ISC",
+			"optional": true
+		},
 		"node_modules/hasown": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
@@ -3944,6 +4585,13 @@
 			"engines": {
 				"node": "^20.17.0 || >=22.9.0"
 			}
+		},
+		"node_modules/http-cache-semantics": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+			"integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+			"license": "BSD-2-Clause",
+			"optional": true
 		},
 		"node_modules/http-proxy-agent": {
 			"version": "7.0.2",
@@ -3986,6 +4634,29 @@
 			},
 			"engines": {
 				"node": ">= 14"
+			}
+		},
+		"node_modules/humanize-ms": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+			"integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"ms": "^2.0.0"
+			}
+		},
+		"node_modules/iconv-lite": {
+			"version": "0.6.3",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+			"integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"safer-buffer": ">= 2.1.2 < 3.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/ieee754": {
@@ -4033,11 +4704,62 @@
 			"integrity": "sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g==",
 			"license": "MIT"
 		},
+		"node_modules/imurmurhash": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+			"integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">=0.8.19"
+			}
+		},
+		"node_modules/indent-string": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+			"integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/infer-owner": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
+			"integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==",
+			"license": "ISC",
+			"optional": true
+		},
+		"node_modules/inflight": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+			"integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+			"deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+			"license": "ISC",
+			"optional": true,
+			"dependencies": {
+				"once": "^1.3.0",
+				"wrappy": "1"
+			}
+		},
+		"node_modules/inherits": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+			"license": "ISC"
+		},
+		"node_modules/ini": {
+			"version": "1.3.8",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+			"integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+			"license": "ISC"
+		},
 		"node_modules/ip-address": {
 			"version": "10.1.0",
 			"resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
 			"integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 12"
@@ -4090,7 +4812,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
 			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -4101,6 +4823,13 @@
 			"resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.2.tgz",
 			"integrity": "sha512-lw7DUp0aWXYg+CBCN+JKkcE0Q2RayZnSvnZBlwgxHBQhqt5pZNVy4Ri7H9GmmXkdu7LUthszM+Tor1u/2iBcpQ==",
 			"license": "MIT"
+		},
+		"node_modules/is-lambda": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
+			"integrity": "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==",
+			"license": "MIT",
+			"optional": true
 		},
 		"node_modules/is-number": {
 			"version": "3.0.0",
@@ -4128,6 +4857,13 @@
 			"engines": {
 				"node": ">=0.10.0"
 			}
+		},
+		"node_modules/isexe": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+			"license": "ISC",
+			"optional": true
 		},
 		"node_modules/isomorphic-fetch": {
 			"version": "3.0.0",
@@ -4495,6 +5231,117 @@
 				"node": "20 || >=22"
 			}
 		},
+		"node_modules/make-fetch-happen": {
+			"version": "9.1.0",
+			"resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-9.1.0.tgz",
+			"integrity": "sha512-+zopwDy7DNknmwPQplem5lAZX/eCOzSvSNNcSKm5eVwTkOBzoktEfXsa9L23J/GIRhxRsaxzkPEhrJEpE2F4Gg==",
+			"license": "ISC",
+			"optional": true,
+			"dependencies": {
+				"agentkeepalive": "^4.1.3",
+				"cacache": "^15.2.0",
+				"http-cache-semantics": "^4.1.0",
+				"http-proxy-agent": "^4.0.1",
+				"https-proxy-agent": "^5.0.0",
+				"is-lambda": "^1.0.1",
+				"lru-cache": "^6.0.0",
+				"minipass": "^3.1.3",
+				"minipass-collect": "^1.0.2",
+				"minipass-fetch": "^1.3.2",
+				"minipass-flush": "^1.0.5",
+				"minipass-pipeline": "^1.2.4",
+				"negotiator": "^0.6.2",
+				"promise-retry": "^2.0.1",
+				"socks-proxy-agent": "^6.0.0",
+				"ssri": "^8.0.0"
+			},
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/make-fetch-happen/node_modules/agent-base": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+			"integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 6.0.0"
+			}
+		},
+		"node_modules/make-fetch-happen/node_modules/http-proxy-agent": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
+			"integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@tootallnate/once": "1",
+				"agent-base": "6",
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/make-fetch-happen/node_modules/https-proxy-agent": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+			"integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"agent-base": "6",
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/make-fetch-happen/node_modules/lru-cache": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+			"license": "ISC",
+			"optional": true,
+			"dependencies": {
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/make-fetch-happen/node_modules/minipass": {
+			"version": "3.3.6",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+			"integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+			"license": "ISC",
+			"optional": true,
+			"dependencies": {
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/make-fetch-happen/node_modules/socks-proxy-agent": {
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-6.2.1.tgz",
+			"integrity": "sha512-a6KW9G+6B3nWZ1yB8G7pJwL3ggLy1uTzKAgCb7ttblwqdz9fMGJUuTy3uFzEP48FAs9FLILlmzDlE2JJhVQaXQ==",
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"agent-base": "^6.0.2",
+				"debug": "^4.3.3",
+				"socks": "^2.6.2"
+			},
+			"engines": {
+				"node": ">= 10"
+			}
+		},
 		"node_modules/marked": {
 			"version": "15.0.12",
 			"resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
@@ -4547,6 +5394,18 @@
 				"url": "https://opencollective.com/express"
 			}
 		},
+		"node_modules/mimic-response": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+			"integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/min-document": {
 			"version": "2.19.2",
 			"resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.2.tgz",
@@ -4591,11 +5450,189 @@
 				"node": ">=16 || 14 >=14.17"
 			}
 		},
+		"node_modules/minipass-collect": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-1.0.2.tgz",
+			"integrity": "sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==",
+			"license": "ISC",
+			"optional": true,
+			"dependencies": {
+				"minipass": "^3.0.0"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/minipass-collect/node_modules/minipass": {
+			"version": "3.3.6",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+			"integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+			"license": "ISC",
+			"optional": true,
+			"dependencies": {
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/minipass-fetch": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-1.4.1.tgz",
+			"integrity": "sha512-CGH1eblLq26Y15+Azk7ey4xh0J/XfJfrCox5LDJiKqI2Q2iwOLOKrlmIaODiSQS8d18jalF6y2K2ePUm0CmShw==",
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"minipass": "^3.1.0",
+				"minipass-sized": "^1.0.3",
+				"minizlib": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"optionalDependencies": {
+				"encoding": "^0.1.12"
+			}
+		},
+		"node_modules/minipass-fetch/node_modules/minipass": {
+			"version": "3.3.6",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+			"integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+			"license": "ISC",
+			"optional": true,
+			"dependencies": {
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/minipass-flush": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.7.tgz",
+			"integrity": "sha512-TbqTz9cUwWyHS2Dy89P3ocAGUGxKjjLuR9z8w4WUTGAVgEj17/4nhgo2Du56i0Fm3Pm30g4iA8Lcqctc76jCzA==",
+			"license": "BlueOak-1.0.0",
+			"optional": true,
+			"dependencies": {
+				"minipass": "^3.0.0"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/minipass-flush/node_modules/minipass": {
+			"version": "3.3.6",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+			"integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+			"license": "ISC",
+			"optional": true,
+			"dependencies": {
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/minipass-pipeline": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
+			"integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
+			"license": "ISC",
+			"optional": true,
+			"dependencies": {
+				"minipass": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/minipass-pipeline/node_modules/minipass": {
+			"version": "3.3.6",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+			"integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+			"license": "ISC",
+			"optional": true,
+			"dependencies": {
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/minipass-sized": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-1.0.3.tgz",
+			"integrity": "sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==",
+			"license": "ISC",
+			"optional": true,
+			"dependencies": {
+				"minipass": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/minipass-sized/node_modules/minipass": {
+			"version": "3.3.6",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+			"integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+			"license": "ISC",
+			"optional": true,
+			"dependencies": {
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/minizlib": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+			"integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+			"license": "MIT",
+			"dependencies": {
+				"minipass": "^3.0.0",
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/minizlib/node_modules/minipass": {
+			"version": "3.3.6",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+			"integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+			"license": "ISC",
+			"dependencies": {
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/mkdirp": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+			"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+			"license": "MIT",
+			"bin": {
+				"mkdirp": "bin/cmd.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/mkdirp-classic": {
+			"version": "0.5.3",
+			"resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+			"integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+			"license": "MIT"
+		},
 		"node_modules/ms": {
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
 			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT"
 		},
 		"node_modules/mz": {
@@ -4610,6 +5647,22 @@
 				"thenify-all": "^1.0.0"
 			}
 		},
+		"node_modules/napi-build-utils": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+			"integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+			"license": "MIT"
+		},
+		"node_modules/negotiator": {
+			"version": "0.6.4",
+			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
+			"integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
 		"node_modules/netmask": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/netmask/-/netmask-2.1.1.tgz",
@@ -4619,6 +5672,24 @@
 			"engines": {
 				"node": ">= 0.4.0"
 			}
+		},
+		"node_modules/node-abi": {
+			"version": "3.90.0",
+			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.90.0.tgz",
+			"integrity": "sha512-pZNQT7UnYlMwMBy5N1lV5X/YLTbZM5ncytN3xL7CHEzhDN8uVe0u55yaPUJICIJjaCW8NrM5BFdqr7HLweStNA==",
+			"license": "MIT",
+			"dependencies": {
+				"semver": "^7.3.5"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/node-addon-api": {
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+			"integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+			"license": "MIT"
 		},
 		"node_modules/node-domexception": {
 			"version": "1.0.0",
@@ -4660,11 +5731,122 @@
 				"url": "https://opencollective.com/node-fetch"
 			}
 		},
+		"node_modules/node-gyp": {
+			"version": "8.4.1",
+			"resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-8.4.1.tgz",
+			"integrity": "sha512-olTJRgUtAb/hOXG0E93wZDs5YiJlgbXxTwQAFHyNlRsXQnYzUaF2aGgujZbw+hR8aF4ZG/rST57bWMWD16jr9w==",
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"env-paths": "^2.2.0",
+				"glob": "^7.1.4",
+				"graceful-fs": "^4.2.6",
+				"make-fetch-happen": "^9.1.0",
+				"nopt": "^5.0.0",
+				"npmlog": "^6.0.0",
+				"rimraf": "^3.0.2",
+				"semver": "^7.3.5",
+				"tar": "^6.1.2",
+				"which": "^2.0.2"
+			},
+			"bin": {
+				"node-gyp": "bin/node-gyp.js"
+			},
+			"engines": {
+				"node": ">= 10.12.0"
+			}
+		},
+		"node_modules/node-gyp/node_modules/balanced-match": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+			"license": "MIT",
+			"optional": true
+		},
+		"node_modules/node-gyp/node_modules/brace-expansion": {
+			"version": "1.1.14",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"node_modules/node-gyp/node_modules/glob": {
+			"version": "7.2.3",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+			"deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+			"license": "ISC",
+			"optional": true,
+			"dependencies": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.1.1",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
+			},
+			"engines": {
+				"node": "*"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/node-gyp/node_modules/minimatch": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+			"license": "ISC",
+			"optional": true,
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
 		"node_modules/noop6": {
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/noop6/-/noop6-1.0.10.tgz",
 			"integrity": "sha512-WZvuCILZFZHK+WuqCQwxLBGllkBK1ct8s8Mu9FMDbEsBE6/bqNxyFGbX7Xky+6bYFL8X2Ou4Cis4CJyrwXLvQA==",
 			"license": "MIT"
+		},
+		"node_modules/nopt": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
+			"integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
+			"license": "ISC",
+			"optional": true,
+			"dependencies": {
+				"abbrev": "1"
+			},
+			"bin": {
+				"nopt": "bin/nopt.js"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/npmlog": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-6.0.2.tgz",
+			"integrity": "sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==",
+			"deprecated": "This package is no longer supported.",
+			"license": "ISC",
+			"optional": true,
+			"dependencies": {
+				"are-we-there-yet": "^3.0.0",
+				"console-control-strings": "^1.1.0",
+				"gauge": "^4.0.3",
+				"set-blocking": "^2.0.0"
+			},
+			"engines": {
+				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+			}
 		},
 		"node_modules/oauth-sign": {
 			"version": "0.9.0",
@@ -4695,7 +5877,6 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"wrappy": "1"
@@ -4721,6 +5902,22 @@
 				"zod": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/p-map": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+			"integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"aggregate-error": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/p-retry": {
@@ -4852,6 +6049,16 @@
 				"node": ">=14.0.0"
 			}
 		},
+		"node_modules/path-is-absolute": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/path-scurry": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
@@ -4938,6 +6145,33 @@
 				"node": ">=12.13.0"
 			}
 		},
+		"node_modules/prebuild-install": {
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+			"integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+			"deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+			"license": "MIT",
+			"dependencies": {
+				"detect-libc": "^2.0.0",
+				"expand-template": "^2.0.3",
+				"github-from-package": "0.0.0",
+				"minimist": "^1.2.3",
+				"mkdirp-classic": "^0.5.3",
+				"napi-build-utils": "^2.0.0",
+				"node-abi": "^3.3.0",
+				"pump": "^3.0.0",
+				"rc": "^1.2.7",
+				"simple-get": "^4.0.0",
+				"tar-fs": "^2.0.0",
+				"tunnel-agent": "^0.6.0"
+			},
+			"bin": {
+				"prebuild-install": "bin.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/process": {
 			"version": "0.11.10",
 			"resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
@@ -4945,6 +6179,37 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.6.0"
+			}
+		},
+		"node_modules/promise-inflight": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
+			"integrity": "sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==",
+			"license": "ISC",
+			"optional": true
+		},
+		"node_modules/promise-retry": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
+			"integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"err-code": "^2.0.2",
+				"retry": "^0.12.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/promise-retry/node_modules/retry": {
+			"version": "0.12.0",
+			"resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+			"integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">= 4"
 			}
 		},
 		"node_modules/proper-lockfile": {
@@ -5047,7 +6312,6 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
 			"integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"end-of-stream": "^1.1.0",
@@ -5070,6 +6334,21 @@
 			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=0.6"
+			}
+		},
+		"node_modules/rc": {
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+			"integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+			"license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+			"dependencies": {
+				"deep-extend": "^0.6.0",
+				"ini": "~1.3.0",
+				"minimist": "^1.2.0",
+				"strip-json-comments": "~2.0.1"
+			},
+			"bin": {
+				"rc": "cli.js"
 			}
 		},
 		"node_modules/readable-stream": {
@@ -5217,6 +6496,76 @@
 				"node": ">= 4"
 			}
 		},
+		"node_modules/rimraf": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+			"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+			"deprecated": "Rimraf versions prior to v4 are no longer supported",
+			"license": "ISC",
+			"optional": true,
+			"dependencies": {
+				"glob": "^7.1.3"
+			},
+			"bin": {
+				"rimraf": "bin.js"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/rimraf/node_modules/balanced-match": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+			"license": "MIT",
+			"optional": true
+		},
+		"node_modules/rimraf/node_modules/brace-expansion": {
+			"version": "1.1.14",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"node_modules/rimraf/node_modules/glob": {
+			"version": "7.2.3",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+			"deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+			"license": "ISC",
+			"optional": true,
+			"dependencies": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.1.1",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
+			},
+			"engines": {
+				"node": "*"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/rimraf/node_modules/minimatch": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+			"integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+			"license": "ISC",
+			"optional": true,
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
 		"node_modules/safe-buffer": {
 			"version": "5.2.1",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -5252,18 +6601,82 @@
 				"node": ">=11.0.0"
 			}
 		},
+		"node_modules/semver": {
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/set-blocking": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+			"integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+			"license": "ISC",
+			"optional": true
+		},
 		"node_modules/signal-exit": {
 			"version": "3.0.7",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
 			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-			"dev": true,
+			"devOptional": true,
 			"license": "ISC"
+		},
+		"node_modules/simple-concat": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+			"integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/simple-get": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+			"integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"decompress-response": "^6.0.0",
+				"once": "^1.3.1",
+				"simple-concat": "^1.0.0"
+			}
 		},
 		"node_modules/smart-buffer": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
 			"integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 6.0.0",
@@ -5274,7 +6687,7 @@
 			"version": "2.8.7",
 			"resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
 			"integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"ip-address": "^10.0.1",
@@ -5311,6 +6724,30 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/sqlite3": {
+			"version": "5.1.7",
+			"resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-5.1.7.tgz",
+			"integrity": "sha512-GGIyOiFaG+TUra3JIfkI/zGP8yZYLPQ0pl1bH+ODjiX57sPhrLU5sQJn1y9bDKZUFYkX1crlrPfSYt0BKKdkog==",
+			"hasInstallScript": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"bindings": "^1.5.0",
+				"node-addon-api": "^7.0.0",
+				"prebuild-install": "^7.1.1",
+				"tar": "^6.1.11"
+			},
+			"optionalDependencies": {
+				"node-gyp": "8.x"
+			},
+			"peerDependencies": {
+				"node-gyp": "8.x"
+			},
+			"peerDependenciesMeta": {
+				"node-gyp": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/sshpk": {
 			"version": "1.18.0",
 			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.18.0.tgz",
@@ -5336,6 +6773,32 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/ssri": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.1.tgz",
+			"integrity": "sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==",
+			"license": "ISC",
+			"optional": true,
+			"dependencies": {
+				"minipass": "^3.1.1"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/ssri/node_modules/minipass": {
+			"version": "3.3.6",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+			"integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+			"license": "ISC",
+			"optional": true,
+			"dependencies": {
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/std-env": {
 			"version": "3.10.0",
 			"resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
@@ -5356,7 +6819,7 @@
 			"version": "4.2.3",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
 			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"emoji-regex": "^8.0.0",
@@ -5371,7 +6834,7 @@
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
 			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -5381,7 +6844,7 @@
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
 			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"ansi-regex": "^5.0.1"
@@ -5404,6 +6867,15 @@
 			},
 			"funding": {
 				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
+			}
+		},
+		"node_modules/strip-json-comments": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+			"integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/strnum": {
@@ -5445,6 +6917,81 @@
 			"dependencies": {
 				"has-flag": "^4.0.0"
 			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/tar": {
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+			"integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
+			"deprecated": "Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+			"license": "ISC",
+			"dependencies": {
+				"chownr": "^2.0.0",
+				"fs-minipass": "^2.0.0",
+				"minipass": "^5.0.0",
+				"minizlib": "^2.1.1",
+				"mkdirp": "^1.0.3",
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/tar-fs": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+			"integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+			"license": "MIT",
+			"dependencies": {
+				"chownr": "^1.1.1",
+				"mkdirp-classic": "^0.5.2",
+				"pump": "^3.0.0",
+				"tar-stream": "^2.1.4"
+			}
+		},
+		"node_modules/tar-fs/node_modules/chownr": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+			"integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+			"license": "ISC"
+		},
+		"node_modules/tar-stream": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+			"integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+			"license": "MIT",
+			"dependencies": {
+				"bl": "^4.0.3",
+				"end-of-stream": "^1.4.1",
+				"fs-constants": "^1.0.0",
+				"inherits": "^2.0.3",
+				"readable-stream": "^3.1.1"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/tar-stream/node_modules/readable-stream": {
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+			"license": "MIT",
+			"dependencies": {
+				"inherits": "^2.0.3",
+				"string_decoder": "^1.1.1",
+				"util-deprecate": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/tar/node_modules/minipass": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+			"integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+			"license": "ISC",
 			"engines": {
 				"node": ">=8"
 			}
@@ -5633,6 +7180,26 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/unique-filename": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
+			"integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
+			"license": "ISC",
+			"optional": true,
+			"dependencies": {
+				"unique-slug": "^2.0.0"
+			}
+		},
+		"node_modules/unique-slug": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz",
+			"integrity": "sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==",
+			"license": "ISC",
+			"optional": true,
+			"dependencies": {
+				"imurmurhash": "^0.1.4"
+			}
+		},
 		"node_modules/uri-js": {
 			"version": "4.4.1",
 			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -5650,6 +7217,12 @@
 			"dependencies": {
 				"pako": "^1.0.11"
 			}
+		},
+		"node_modules/util-deprecate": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+			"license": "MIT"
 		},
 		"node_modules/uuid": {
 			"version": "14.0.0",
@@ -5709,6 +7282,32 @@
 			"dependencies": {
 				"tr46": "~0.0.3",
 				"webidl-conversions": "^3.0.0"
+			}
+		},
+		"node_modules/which": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+			"license": "ISC",
+			"optional": true,
+			"dependencies": {
+				"isexe": "^2.0.0"
+			},
+			"bin": {
+				"node-which": "bin/node-which"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/wide-align": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
+			"integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
+			"license": "ISC",
+			"optional": true,
+			"dependencies": {
+				"string-width": "^1.0.2 || 2 || 3 || 4"
 			}
 		},
 		"node_modules/window-size": {
@@ -5772,7 +7371,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
 			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/ws": {
@@ -5855,6 +7453,12 @@
 			"engines": {
 				"node": ">=10"
 			}
+		},
+		"node_modules/yallist": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+			"license": "ISC"
 		},
 		"node_modules/yaml": {
 			"version": "2.8.3",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
 	},
 	"pi": {
 		"extensions": [
-			"./.pi/extensions"
+			"./.pi/extensions",
+			"./.pi/providers"
 		],
 		"skills": [
 			"./.agents/skills"
@@ -39,6 +40,7 @@
 		"typescript": "^6.0.3"
 	},
 	"dependencies": {
+		"@cursor/sdk": "^1.0.12",
 		"asciify-image": "^0.1.10"
 	}
 }

--- a/vault/wiki/decisions/adr-026.md
+++ b/vault/wiki/decisions/adr-026.md
@@ -1,0 +1,56 @@
+---
+type: decision
+title: "ADR-026: Replace CLI Cursor Provider with Native Cursor SDK Provider"
+status: accepted
+priority: 1
+date: "2026-05-04"
+tags: [adr, provider, cursor, sdk, pi]
+sources:
+  - "https://pi.dev/docs/latest/custom-provider"
+  - "https://cursor.com/docs/api/sdk/typescript"
+related:
+  - "[[adr-012]]"
+created: 2026-05-04
+updated: 2026-05-04
+---
+
+# ADR-026: Replace CLI Cursor Provider with Native Cursor SDK Provider
+
+## Context
+
+Current setup used `npm:@netandreus/pi-cursor-provider`, which wrapped Cursor CLI calls.
+That path was brittle and not purely programmatic.
+
+Project needs clean provider integration through Pi `registerProvider(..., streamSimple)` and Cursor TypeScript SDK.
+
+## Decision
+
+Use repo-local extension `.pi/extensions/cursor-sdk-provider.ts`.
+
+- Register provider name: `cursor-sdk`
+- Implement `streamSimple` using `@cursor/sdk` (`Agent.create`, `agent.send`, `run.stream`, `run.wait`)
+- Remove `npm:@netandreus/pi-cursor-provider` from `.pi/settings.json`
+- Keep auth via `CURSOR_API_KEY`
+
+## Alternatives considered
+
+1. Keep external CLI package
+   - Rejected: CLI indirection, less control, hacky behavior.
+2. Keep external package but fork it
+   - Rejected: extra maintenance for little gain.
+
+## Rationale
+
+Cursor SDK gives stable programmatic API, event stream access, and direct TypeScript types.
+Pi custom-provider API supports this natively through `streamSimple`.
+
+## Consequences
+
+### Positive
+- Cleaner architecture
+- No CLI shell glue
+- Local code ownership of provider behavior
+
+### Negative
+- Must maintain local provider extension on future SDK changes
+- Initial model defaults may need tuning per team account/model availability


### PR DESCRIPTION
- add local cursor-sdk provider extension with model mapping and tool-call bridging\n- register .pi/providers extension path and add @cursor/sdk dependency\n- remove external pi-cursor-provider package from Pi settings\n- update model-router defaults/fallbacks for current Cursor model IDs\n- remove deprecated browser harness config file\n- add ADR-026 documenting provider migration decision

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it introduces a new runtime provider implementation and a heavy new dependency chain (`@cursor/sdk` incl. native `sqlite3`), which could affect installs and streaming/tool-call behavior at runtime.
> 
> **Overview**
> Replaces the external Cursor CLI-based provider with a repo-local `@cursor/sdk` provider (`.pi/providers/cursor-sdk-provider.ts`) that streams responses and bridges Cursor tool events/plain-text tool calls into Pi `toolCall` events.
> 
> Updates Pi configuration to load providers from `./.pi/providers`, drops `npm:@netandreus/pi-cursor-provider` from `.pi/settings.json`, and adjusts `.pi/model-router.json` defaults/fallbacks to current Cursor model IDs.
> 
> Adds the `@cursor/sdk` dependency (lockfile updates), removes the deprecated `.pi/harness/browser.json`, and documents the migration in `ADR-026`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1c84ffd3b19634679a4effc9d8dc1a51de94af2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->