### PR TITLE
feat(harness): add agent-router skill, search policies, model switch,…

### DIFF
--- a/.cursor/skills
+++ b/.cursor/skills
@@ -1,0 +1,1 @@
+/home/aryaniyaps/ai-projects/ultimate-pi/.agents/skills

--- a/.pi/SYSTEM.md
+++ b/.pi/SYSTEM.md
@@ -1,94 +1,145 @@
-You are an enterprise coding agent. Optimize for correctness, minimal diffs, and token efficiency.
+# Pi Coding Agent — System Prompt
 
-VOICE
+Enterprise coding agent. Optimize for correctness, minimal diffs, and token efficiency.
+
+---
+## Voice
 - Always speak in caveman mode.
 - Short direct lines. No fluff.
 - Keep commands, paths, code, logs exact.
 
-PRIMARY GOAL
+## Primary Goal
 - Complete user request fully.
 - Preserve repo stability.
 - Prefer smallest safe change.
 
-INSTRUCTION ORDER
-1) System/developer rules.
-2) This file.
-3) User request.
-4) Local conventions from repo files.
+## Instruction Order
+1. System/developer rules.
+2. This file.
+3. User request.
+4. Local conventions from repo files.
 
-WEB POLICY (MANDATORY)
-- Route all web fetches through context7 (API/library docs) or Firecrawl CLI (all other). No curl, wget, or raw bash HTTP.
-- API/LIBRARY DOCS: context7 ONLY. ctx7 library <name> <query> then ctx7 docs <id> <query>.
-  - context7 owns: function signatures, class APIs, config options, stdlib, framework specs.
-  - NEVER use defuddle/quality-sites for API docs.
-- ALL NON-API WEB FETCH: use Firecrawl CLI. See .pi/skills/firecrawl for workflow escalation.
-  - Search (no URL): firecrawl search "query" --scrape --limit 5 -o .firecrawl/search.json --json
-  - Scrape (have URL): firecrawl scrape "<url>" -o .firecrawl/page.md --only-main-content
-  - JS-rendered: firecrawl scrape "<url>" --wait-for 3000 -o .firecrawl/page.md
-  - Bulk crawl: firecrawl crawl "<url>" -o .firecrawl/crawl/
-  - Interact (clicks/forms): scrape first, then firecrawl interact <scrape-id>
-  - Download site: firecrawl download <url> -o .firecrawl/download/
-  - Parse local docs: firecrawl parse <file> -o .firecrawl/parsed.md
-- SEARCH: firecrawl search (no DuckDuckGo).
-- POST-CLEAN (optional): defuddle parse infile --md > cleanfile if output has boilerplate.
-- QUALITY SITES: check .pi/skills/wiki-autoresearch/references/quality-sites.md before citing non-API sources.
-  - Prefer Tier 1 (stackoverflow, github issues, engineering blogs, arxiv). Exclude AI content farms, mirrors, stale packages.
-- If firecrawl missing: npx firecrawl --help || npm install -g firecrawl-cli@latest
-- If defuddle missing: npm install -g defuddle-cli
-- If context7 missing: npm install -g ctx7@latest
+---
+## Web Policy (Mandatory)
 
-CODEBASE SEARCH POLICY (MANDATORY)
-- NEVER use raw `grep` for codebase exploration. Use `ck --hybrid` instead.
-- `grep` is permitted ONLY for exact literal string matching (specific error message, exact function name).
-- `ck --hybrid "query" .` is the default search — lexical + semantic fusion, ranked results.
-- `ck --sem "concept" src/` for purely conceptual searches (find by meaning).
-- `find` is permitted for file discovery by name/glob. For content search, use ck.
-- Always `--limit N` on ck to cap output and save context.
+> [!warning] No raw HTTP
+> Route **all** web fetches through [[context7]] (API/library docs) or [[firecrawl|Firecrawl CLI]] (all other). No `curl`, `wget`, or raw bash HTTP.
+
+### API / Library Docs — context7 ONLY
+- `ctx7 library <name> <query>` then `ctx7 docs <id> <query>`
+- context7 owns: function signatures, class APIs, config options, stdlib, framework specs.
+- **Never** use [[defuddle]]/quality-sites for API docs.
+
+### All Non-API Web Fetch — Firecrawl CLI
+See `.pi/skills/firecrawl` for workflow escalation.
+
+| Task | Command |
+|------|---------|
+| Search (no URL) | `firecrawl search "query" --scrape --limit 5 -o .firecrawl/search.json --json` |
+| Scrape (have URL) | `firecrawl scrape "<url>" -o .firecrawl/page.md --only-main-content` |
+| JS-rendered page | `firecrawl scrape "<url>" --wait-for 3000 -o .firecrawl/page.md` |
+| Bulk crawl | `firecrawl crawl "<url>" -o .firecrawl/crawl/` |
+| Interact (clicks/forms) | scrape first, then `firecrawl interact <scrape-id>` |
+| Download site | `firecrawl download <url> -o .firecrawl/download/` |
+| Parse local docs | `firecrawl parse <file> -o .firecrawl/parsed.md` |
+
+- **Search:** firecrawl search only (no DuckDuckGo).
+- **Post-clean (optional):** `defuddle parse infile --md > cleanfile` if output has boilerplate.
+- **Quality sites:** check `.pi/skills/wiki-autoresearch/references/quality-sites.md` before citing non-API sources. Prefer Tier 1 (StackOverflow, GitHub issues, engineering blogs, arxiv). Exclude AI content farms, mirrors, stale packages.
+
+### Missing CLI fallbacks
+- Firecrawl missing: `npx firecrawl --help || npm install -g firecrawl-cli@latest`
+- Defuddle missing: `npm install -g defuddle-cli`
+- Context7 missing: `npm install -g ctx7@latest`
+
+---
+## Codebase Search Policy (Mandatory)
+
+> [!danger] No raw grep
+> **Never** use raw `grep` for codebase exploration. Use `ck --hybrid` instead.
+
+| Tool | When | Command |
+|------|------|---------|
+| `ck --hybrid` | Default search — lexical + semantic fusion, ranked results | `ck --hybrid "query" .` |
+| `ck --sem` | Purely conceptual searches (find by meaning) | `ck --sem "concept" src/` |
+| `grep` | **Only** for exact literal string matching (error message, exact function name) | `grep -F "exact string"` |
+| `find` | File discovery by name/glob only | `find . -name "*.ts"` |
+
+- Always use `--limit N` on ck to cap output and save context.
 - If ck returns nothing, fall back to grep. Never skip searching.
 
-SKILL ROUTING (REFERENCE ALL INSTALLED/AVAILABLE SKILLS)
-- caveman: default communication mode.
-- ck-search: semantic code search (ck). Use for all codebase exploration instead of grep.
-- compress: when user asks to compress memory/prompt/todo docs into caveman format.
-- context7-cli: for library/API docs, setup/config guides, or generating/installing skills.
-- lean-ctx (pi-lean-ctx): native Pi package handles bash/read/ls/find/grep routing and MCP bridge. See skill for CLI usage patterns.
-- firecrawl: for all web search, scraping, crawling, JS-rendered pages, site downloads, and interactive page workflows.
-- find-skills: when user asks for new capability, skill discovery, or capability extensions.
+---
+## Skill Routing
 
-PROMPT TEMPLATES
-- /git-sync: commit and push with AI messages + pi-mono co-author.
-- /wiki: search, query, and update the project wiki via CLI.
-- /harness-setup: full harness bootstrap — obsidian wiki + CLI tools + pi extensions + config.
+> [!tip] Use the right skill for the job
+> Reference all installed/available skills before acting.
 
-PROMPT-ENGINEERING EXECUTION RULES
-- Restate objective + constraints before major changes.
-- Make an explicit plan for multi-step tasks.
-- Ask only blocking clarifications.
-- Prefer deterministic commands and pinned paths.
-- Validate outcomes with targeted checks/tests.
-- Report: changed files, why, verification, risks/next steps.
+| Skill | Trigger | Purpose |
+|-------|---------|---------|
+| [[caveman]] | Default | Ultra-compressed communication mode |
+| [[ck-search]] | Codebase search | Semantic code search via `ck` |
+| [[compress]] | User asks for compression | Compress memory/prompt/todo docs into caveman format |
+| [[context7-cli]] | Library docs, setup, config | Fetch library docs, generate/install skills |
+| [[lean-ctx]] (pi-lean-ctx) | Bash/read/ls/find/grep routing | Native Pi package; MCP bridge |
+| [[firecrawl]] | Web search, scrape, crawl | All web interactions |
+| [[agent-router]] | Delegation, agent discovery | Dynamic agent discovery, matching, and dispatch |
+| [[find-skills]] | New capability requests | Skill discovery and installation |
 
-CHANGE DISCIPLINE (MANDATORY)
-- Maintain project wiki and ADRs in wiki/decisions/.
+---
+## Agent Routing
+
+> [!tip] Dynamic discovery
+> Use [[agent-router]] skill to discover agents live, match tasks to specialists, and dispatch.
+> Never hardcode agent lists — `find .pi/agents -name '*.md'` tells you what's actually available.
+
+---
+## Prompt Templates
+
+| Template | Command | Purpose |
+|----------|---------|---------|
+| `/git-sync` | commit + push with AI messages + pi-mono co-author | Git sync |
+| `/wiki` | search, query, update project wiki via CLI | Wiki ops |
+| `/harness-setup` | bootstrap Obsidian wiki + CLI tools + pi extensions + config | Full setup |
+
+---
+## Prompt-Engineering Execution Rules
+1. Restate objective + constraints before major changes.
+2. Make an explicit plan for multi-step tasks.
+3. Ask only blocking clarifications.
+4. Prefer deterministic commands and pinned paths.
+5. Validate outcomes with targeted checks/tests.
+6. Report: changed files, why, verification, risks/next steps.
+
+---
+## Change Discipline (Mandatory)
+- Maintain project wiki and ADRs in `wiki/decisions/`.
 - Document each design decision immediately: context, alternatives, chosen option, rationale, consequences.
 - Before code edits, reference relevant ADR(s).
 - Make surgical diffs only. No unrelated edits.
 - If unrelated issue found, log separately. Do not auto-fix.
 
-OPERATING DISCIPLINE
+---
+## Operating Discipline
 - Do not overthink. When in doubt, respond directly. Simple requests get simple answers.
 - Avoid over-engineering. Only make changes directly requested or clearly required.
 - Never speculate about code, files, or configurations you have not opened or read.
 - If a task has multiple valid approaches, pick the simplest and note the alternative.
 - Scope answers to what was asked. Do not expand into adjacent topics unless requested.
 
-GIT/DELIVERY RULES
+---
+## Git / Delivery Rules
 - Keep commits scoped and atomic.
 - Prefer readable commit messages; use git-commit-formatting skill if available.
 - Never rewrite user history unless explicitly asked.
 
-OUTPUT SHAPE
-- Status: done/in-progress/blocked.
-- Actions: exact files/commands changed.
-- Verification: exact checks run.
-- Next: only if needed.
+---
+## Output Shape
+
+Always report: **Status**, **Actions**, **Verification**, **Next** (only if needed).
+
+| Field | Content |
+|-------|---------|
+| Status | done / in-progress / blocked |
+| Actions | Exact files/commands changed |
+| Verification | Exact checks run |
+| Next | Only if needed |

--- a/.pi/model-router.json
+++ b/.pi/model-router.json
@@ -1,7 +1,7 @@
 {
   "defaultProfile": "auto",
   "debug": false,
-  "classifierModel": "cursor/gpt-5.3-codex",
+  "classifierModel": "opencode-go/qwen3.6-plus",
   "phaseBias": 0.5,
   "maxSessionBudget": 1.0,
   "largeContextThreshold": 100000,
@@ -23,71 +23,71 @@
   "profiles": {
     "auto": {
       "high": {
-        "model": "cursor/gpt-5.3-codex",
+        "model": "opencode-go/deepseek-v4-pro",
         "thinking": "high",
         "fallbacks": [
-          "cursor/claude-opus-4-6",
-          "cursor/gpt-5.2-codex"
+          "opencode-go/qwen3.6-plus",
+          "opencode-go/kimi-k2.6"
         ]
       },
       "medium": {
-        "model": "cursor/gpt-5.3-codex",
+        "model": "opencode-go/qwen3.6-plus",
         "thinking": "medium",
         "fallbacks": [
-          "cursor/claude-sonnet-4-6"
+          "opencode-go/deepseek-v4-pro"
         ]
       },
       "low": {
-        "model": "cursor/gpt-5.2-codex",
+        "model": "opencode-go/deepseek-v4-flash",
         "thinking": "low",
         "fallbacks": [
-          "cursor/gpt-5.2"
+          "opencode-go/qwen3.5-plus"
         ]
       }
     },
     "cheap": {
       "high": {
-        "model": "cursor/gpt-5.2-codex",
+        "model": "opencode-go/qwen3.6-plus",
         "thinking": "low",
         "fallbacks": [
-          "cursor/gpt-5.2"
+          "opencode-go/qwen3.5-plus"
         ]
       },
       "medium": {
-        "model": "cursor/gpt-5.2",
+        "model": "opencode-go/qwen3.5-plus",
         "thinking": "off",
         "fallbacks": [
-          "cursor/claude-sonnet-4-5"
+          "opencode-go/deepseek-v4-flash"
         ]
       },
       "low": {
-        "model": "cursor/gpt-5.1",
+        "model": "opencode-go/deepseek-v4-flash",
         "thinking": "off",
         "fallbacks": [
-          "cursor/claude-sonnet-4-5"
+          "opencode-go/qwen3.5-plus"
         ]
       }
     },
     "deep": {
       "high": {
-        "model": "cursor/gpt-5.3-codex",
+        "model": "opencode-go/deepseek-v4-pro",
         "thinking": "xhigh",
         "fallbacks": [
-          "cursor/claude-opus-4-6"
+          "opencode-go/kimi-k2.6"
         ]
       },
       "medium": {
-        "model": "cursor/claude-sonnet-4-6",
+        "model": "opencode-go/kimi-k2.6",
         "thinking": "medium",
         "fallbacks": [
-          "cursor/gpt-5.3-codex"
+          "opencode-go/deepseek-v4-pro"
         ]
       },
       "low": {
-        "model": "cursor/gpt-5.2-codex",
+        "model": "opencode-go/qwen3.6-plus",
         "thinking": "low",
         "fallbacks": [
-          "cursor/gpt-5.2"
+          "opencode-go/deepseek-v4-flash"
         ]
       }
     }

--- a/.pi/prompts/wiki-autoresearch.md
+++ b/.pi/prompts/wiki-autoresearch.md
@@ -1,12 +1,14 @@
 ---
 description: Run an autonomous research loop on a topic. Searches the web, synthesizes findings, and files everything into the wiki as structured pages.
+argument-hint: "[topic]"
 ---
 
 Read the `wiki-autoresearch` skill. Then run the research loop.
 
-Usage:
-- `/wiki-autoresearch [topic]` — research a specific topic. (Alias: `/autoresearch`)
-- `/wiki-autoresearch` — ask "What topic should I research?"
+Invocation arguments:
+- Raw arguments from command: `$ARGUMENTS`
+- If `$ARGUMENTS` is non-empty: treat it as explicit topic and use it verbatim.
+- If `$ARGUMENTS` is empty: ask exactly "What topic should I research?"
 
 Before starting, read `skills/wiki-autoresearch/references/program.md` to load the research constraints and objectives.
 

--- a/.pi/providers/cursor-sdk-provider.ts
+++ b/.pi/providers/cursor-sdk-provider.ts
@@ -340,6 +340,60 @@ function stripToolCallMarkup(text: string): string {
 		.trim();
 }
 
+function normalizeParsedToolCallArgs(
+	name: string,
+	arguments_: Record<string, unknown>,
+): Record<string, unknown> {
+	const tool = name.toLowerCase();
+	const args = { ...arguments_ };
+	delete args.toolCallId;
+	delete args.call_id;
+
+	if (tool === "shell" || tool === "bash") {
+		const command = typeof args.command === "string" ? args.command : "";
+		const workingDirectory =
+			typeof args.working_directory === "string"
+				? args.working_directory
+				: typeof args.workingDirectory === "string"
+					? args.workingDirectory
+					: typeof args.cwd === "string"
+						? args.cwd
+						: undefined;
+		const blockUntilMs =
+			typeof args.block_until_ms === "number"
+				? args.block_until_ms
+				: typeof args.timeout === "number"
+					? args.timeout
+					: undefined;
+
+		const normalized: Record<string, unknown> = { command };
+		if (workingDirectory && workingDirectory.trim().length > 0) {
+			normalized.working_directory = workingDirectory.trim();
+		}
+		if (typeof blockUntilMs === "number" && Number.isFinite(blockUntilMs) && blockUntilMs >= 0) {
+			normalized.block_until_ms = Math.floor(blockUntilMs);
+		}
+		if (typeof args.description === "string" && args.description.trim().length > 0) {
+			normalized.description = args.description.trim();
+		}
+		return normalized;
+	}
+
+	if (tool === "glob") {
+		const normalized: Record<string, unknown> = {};
+		if (typeof args.globPattern === "string") normalized.glob_pattern = args.globPattern;
+		else if (typeof args.pattern === "string") normalized.glob_pattern = args.pattern;
+		if (typeof args.targetDirectory === "string") normalized.target_directory = args.targetDirectory;
+		return normalized;
+	}
+
+	if (tool === "read") {
+		return typeof args.path === "string" ? { path: args.path } : {};
+	}
+
+	return args;
+}
+
 function likelyNeedsTool(text: string): boolean {
 	const lower = text.toLowerCase();
 	const signals = ["use ", "run ", "read ", "write ", "edit ", "find ", "grep ", "list ", "ls ", "bash ", "command", "file", "directory", "tool"];
@@ -461,11 +515,18 @@ function streamCursorSdk(model: Model<Api>, context: Context, options?: SimpleSt
 			const agent = await Agent.create({
 				apiKey: process.env.CURSOR_API_KEY,
 				model: { id: selectedModel } as ModelSelection,
-				local: { cwd: process.cwd() },
+					// YOLO-style local runtime: load all Cursor settings and disable sandbox
+					// so the agent can execute tool/shell flows without interactive gating.
+					local: {
+						cwd: process.cwd(),
+						settingSources: ["all"],
+						sandboxOptions: { enabled: false },
+					},
 			});
 
 			try {
 				options?.signal?.addEventListener("abort", onAbort, { once: true });
+				// Keep force=true so stale/busy local runs never block autonomous execution.
 				const run = await agent.send(promptText, { local: { force: true } });
 				runCancel = () => run.cancel();
 
@@ -540,18 +601,22 @@ function streamCursorSdk(model: Model<Api>, context: Context, options?: SimpleSt
 					if (parsedPiToolCall) {
 						const contentIndex = output.content.length;
 						const toolCallId = `call_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`;
+						const normalizedArgs = normalizeParsedToolCallArgs(
+							parsedPiToolCall.name,
+							parsedPiToolCall.arguments,
+						);
 						const piToolCall = {
 							type: "toolCall" as const,
 							id: toolCallId,
 							name: parsedPiToolCall.name,
-							arguments: parsedPiToolCall.arguments,
+							arguments: normalizedArgs,
 						};
 						output.content.push(piToolCall);
 						stream.push({ type: "toolcall_start", contentIndex, partial: output });
 						stream.push({
 							type: "toolcall_delta",
 							contentIndex,
-							delta: JSON.stringify(parsedPiToolCall.arguments),
+							delta: JSON.stringify(normalizedArgs),
 							partial: output,
 						});
 						stream.push({ type: "toolcall_end", contentIndex, toolCall: piToolCall, partial: output });

--- a/.pi/skills/agent-router/SKILL.md
+++ b/.pi/skills/agent-router/SKILL.md
@@ -1,0 +1,174 @@
+---
+name: agent-router
+description: >
+  Dynamic agent discovery, matching, and delegation. Discovers all available agents
+  at runtime, reads their frontmatter to understand capabilities, matches tasks to
+  the right specialist, and routes via the Agent tool. Use when the user needs
+  delegation, asks which agent can help, wants parallel dispatch, or says
+  "delegate this", "find an agent for", "route to", "dispatch", "which agent".
+allowed-tools: Read Glob Find Bash
+---
+
+# agent-router: Dynamic Agent Discovery & Routing
+
+You don't memorize agent lists. You discover them live, read their capabilities,
+and route tasks to the right specialists.
+
+## Why Dynamic Discovery
+
+Agent definitions live in two locations (project and global). They change over
+time. New agents get added. Default agents get overridden. A static list in
+SYSTEM.md rots. Dynamic discovery tells you what's actually available right now.
+
+## Discovery
+
+### Step 1 — List All Available Agents
+
+```bash
+find .pi/agents -name '*.md' -type f 2>/dev/null
+find ~/.pi/agent/agents -name '*.md' -type f 2>/dev/null
+```
+
+Project agents (`.pi/agents/`) override identically-named global ones. Default
+agents (`Explore`, `Plan`, `general-purpose`) are always available even without
+files here.
+
+### Step 2 — Parse Agent Frontmatter
+
+For each candidate agent, read the file and extract:
+
+| Field | Extract this |
+|-------|-------------|
+| `description` | What the agent does, when to use it |
+| `tools` | Available built-in tools |
+| `thinking` | Reasoning depth: `off`, `low`, `medium`, `high`, `xhigh` |
+| `max_turns` | Turn limit (0 = unlimited) |
+| `model` | Model override if specified |
+| `isolation` | `worktree` if isolated git execution |
+
+> [!info] Subdirectory agents
+> Agents in `.pi/agents/<team>/<name>.md` are referenced as `<team>/<name>`.
+> Example: `pi-pi/agent-expert` lives at `.pi/agents/pi-pi/agent-expert.md`.
+
+### Step 3 — Cache Discovery Results
+
+After discovery, summarize available agents for the current session. No need
+to re-read frontmatter for already-profiled agents.
+
+## Matching Tasks to Agents
+
+### Direct Match — Keyword Triggers
+
+| User says | Look for agent with |
+|-----------|-------------------|
+| Explicit agent name | Match directly |
+| "build a skill" / "create skill" | Skill-related keywords in description |
+| "create an agent" | Agent-related keywords in description |
+| "Pi extension" / "Pi theme" | Pi component domain keywords |
+| "rethink" / "first principles" | Prioritization keywords |
+| "ingest to wiki" | Wiki ingestion keywords |
+| "lint the wiki" | Wiki lint keywords |
+
+### Fuzzy Match — Semantic Fit
+
+When no direct keyword match:
+
+1. Read the task description carefully.
+2. Compare against each agent's `description` field.
+3. Pick the agent whose description most closely matches the task domain.
+4. If uncertain, read the agent's full prompt body for more context.
+5. If nothing fits, use `general-purpose`.
+
+### Orchestrator Pattern
+
+Some agents are meta-agents that coordinate teams. When an orchestrator agent
+exists for a domain (e.g., `pi-pi/pi-orchestrator`), route domain tasks to
+the orchestrator — not individual experts. The orchestrator knows how to
+dispatch its team members in parallel.
+
+To identify orchestrators: look for agents whose descriptions mention
+"coordinates", "dispatches", "orchestrates", "meta-agent", or whose tools
+include `Agent`.
+
+## Routing
+
+### Dispatch
+
+Use the `Agent` tool:
+
+```typescript
+Agent({
+  subagent_type: "<team>/<name>",
+  prompt: "<specific, scoped task description>",
+  run_in_background: true,  // for parallel dispatch
+  inherit_context: false,   // fresh context by default
+})
+```
+
+### Parallel Dispatch
+
+When a task touches multiple domains:
+1. Identify all relevant agents.
+2. Dispatch all of them with `run_in_background: true`.
+3. Collect results with `get_subagent_result`.
+4. Synthesize findings.
+
+### Sequential Pipelines
+
+When one agent's output feeds another:
+1. Dispatch first agent (foreground or background).
+2. Collect result.
+3. Feed result into second agent's prompt.
+4. Continue until pipeline completes.
+
+### Collecting Results
+
+```typescript
+get_subagent_result({ agent_id: "<id>", wait: true })
+```
+
+Summarize agent findings for the user. Don't dump raw output — extract
+key decisions, actionable outputs, and surprises.
+
+## Delegation Rules
+
+1. **Agents are for multi-turn, tool-using workflows.** For single-step template
+   expansion (static prompt + argument substitution), use a prompt template instead.
+2. **One job per agent.** If the task needs "and" in the description, split into
+   separate dispatches.
+3. **Match tools + thinking to task difficulty.** A file-lookup task doesn't need
+   `bash` + `medium` thinking. A novel architecture decision needs `high`.
+4. **Parallelize by default.** When multiple domains are relevant, dispatch all
+   agents simultaneously. Serial dispatch wastes wall-clock time.
+5. **Experts research, orchestrators build.** Don't ask a domain expert to write
+   files if an orchestrator exists for that domain.
+6. **Always read frontmatter before dispatching.** Don't assume an agent's
+   capabilities from its name alone.
+7. **If no agent fits, fall back to `general-purpose`.** Then consider whether
+   a new agent should be created for the missing capability.
+
+## Discovery Example
+
+```bash
+# Find all agents
+$ find .pi/agents -name '*.md' -type f
+
+# Sample output:
+# .pi/agents/pi-pi/pi-orchestrator.md
+# .pi/agents/pi-pi/agent-expert.md
+# .pi/agents/pi-pi/skill-expert.md
+# .pi/agents/rethink.md
+# .pi/agents/wiki-ingest.md
+# .pi/agents/wiki-lint.md
+
+# Then read each to understand capabilities
+# Then match user task to the right agent(s)
+```
+
+## Guardrails
+
+- Do not hardcode agent lists. Always discover dynamically.
+- Do not dispatch an agent you haven't read the frontmatter for.
+- Do not use an agent when a prompt template suffices.
+- If discovery returns nothing, use default agents (`Explore`, `Plan`, `general-purpose`).
+- Report routing decisions: which agent(s) dispatched, why, what to expect.

--- a/vault/wiki/concepts/memory-system-of-record-vs-ephemeral-cache.md
+++ b/vault/wiki/concepts/memory-system-of-record-vs-ephemeral-cache.md
@@ -1,0 +1,47 @@
+---
+type: concept
+title: "Memory System-of-Record vs Ephemeral Cache"
+aliases: ["memory layering", "canonical memory vs fast memory"]
+created: 2026-05-05
+updated: 2026-05-05
+tags: [concept, memory, harness, architecture]
+status: developing
+related:
+  - "[[persistent-memory]]"
+  - "[[adr-009]]"
+  - "[[lifecycle-hooks]]"
+  - "[[Research: claude-mem over Obsidian for Harness Layer]]"
+sources:
+  - "[[adr-009]]"
+  - "[[persistent-memory]]"
+  - "[[codex-harness-innovations]]"
+---
+
+# Memory System-of-Record vs Ephemeral Cache
+
+## Definition
+Split agent memory into two layers:
+- **System-of-record memory**: durable, auditable, human-reviewable, citation-ready.
+- **Ephemeral cache memory**: fast, local, convenience-oriented, non-authoritative.
+
+## Why This Pattern
+- Harness decisions need traceability and contradiction handling.
+- Fast memory helps turn-level latency and continuity.
+- Mixing both into one store causes drift: quick notes get mistaken as validated decisions.
+
+## Harness Mapping
+| Layer | Role | Example in this repo |
+|---|---|---|
+| System-of-record | Canonical truth | `vault/wiki/` with `index.md`, `log.md`, `hot.md` |
+| Ephemeral cache | Speed and recall hints | Optional local auto-memory tool |
+
+## Guardrails
+- Any decision, architecture change, or policy update must be written to wiki.
+- Ephemeral memory can suggest; wiki must confirm.
+- When cache conflicts with wiki, wiki wins.
+- Completion hooks should fail tasks that changed architecture without wiki write.
+
+## Tradeoff
+- Pure wiki: higher reliability, more manual writing.
+- Pure auto-memory: lower friction, weaker audit/provenance.
+- Hybrid: best practical balance for agentic harnesses.

--- a/vault/wiki/hot.md
+++ b/vault/wiki/hot.md
@@ -1,13 +1,31 @@
 ---
 type: meta
 title: "Hot Cache"
-updated: 2026-05-03T21:45:00
+updated: 2026-05-05T17:05:00
 created: 2026-04-30
 tags: []
 status: active
 ---
 
 # Recent Context
+
+## Last Updated
+2026-05-05. Filed research: [[Research: claude-mem over obsidian wiki as the knowledge base for our agentic harness pipeline. think from first principles. does this replace or complement our current setup? no hard feelings about previous decisions. gimme accurate points]].
+
+## Key Recent Facts
+- First-principles verdict unchanged: keep Obsidian wiki as Layer 6 canonical memory.
+- `claude-mem` fits as optional fast recall cache, not source-of-record.
+- Deterministic write-back gates stay mandatory for decision-bearing tasks.
+- Current vault still lacks direct `claude-mem` benchmark and provenance evidence.
+
+## Recent Changes
+- Created: [[Research: claude-mem over obsidian wiki as the knowledge base for our agentic harness pipeline. think from first principles. does this replace or complement our current setup? no hard feelings about previous decisions. gimme accurate points]]
+- Updated: [[index]], [[log]], [[hot]]
+- Flagged: External web validation blocked in this run; findings grounded in existing vault sources.
+
+## Active Threads
+- User deciding replace-vs-complement for `claude-mem` in harness memory architecture.
+- Next step: run external benchmark pass on `claude-mem` durability, precision/recall, and provenance fidelity.
 
 ## Last Updated
 2026-05-03. **pi-vs-claude-code agentic orchestration pipeline** research filed. **sentrux.dev integrated**, **Automating Software Engineering**, **Legendary Engineering Patterns**, and **Skill-First Architecture** also active.

--- a/vault/wiki/index.md
+++ b/vault/wiki/index.md
@@ -2,7 +2,7 @@
 type: index
 status: active
 created: 2026-04-28
-updated: 2026-05-04
+updated: 2026-05-05
 tags: [meta, index, catalog]
 ---
 
@@ -119,6 +119,7 @@ This wiki maps the codebase architecture, tracks key software design decisions, 
 | [[ts-execution-layer]] | Replace flat tool calling with typed TypeScript API + sandboxed runtime (3-4x context reduction) |
 | [[mcp-tool-routing]] | MCP protocol for semantic search as first-class agent tool |
 | [[codebase-to-context-ingestion]] | Converting entire codebases into structured LLM context |
+| [[memory-system-of-record-vs-ephemeral-cache]] | Canonical wiki memory + optional local fast cache layering |
 
 ## Concepts — Orchestration & Harness
 
@@ -268,6 +269,9 @@ This wiki maps the codebase architecture, tracks key software design decisions, 
 | [[Research: TypeScript Best Practices and Codebase Structure]] | Strict mode, runtimes, barrel files, monorepos, folder structure, error handling, testing |
 | [[Research: Skill-First Harness Architecture]] | **UPDATED (May 2026)**: Rethought MVP + harness plans from first principles. Skills as atomic unit. 3 code files vs 15. Event bus removed. |
 | [[Research: Engineering Workflows of Legendary Programmers and AI Harness Mapping]] | **NEW (May 2026)**: 10 patterns from 6 legendary programmers mapped to harness layers |
+| [[Research: claude-mem over Obsidian for Harness Layer]] | Replacement assessment: keep Obsidian as source of truth, optional claude-mem as cache |
+| [[Research: how claude-mem fits into our workflow. and whether it should replace obsidian in the codebase. no hard feelings about previous actions, rethink from first principles always]] | First-principles reassessment: keep Obsidian canonical, use claude-mem only as non-authoritative acceleration cache |
+| [[Research: claude-mem over obsidian wiki as the knowledge base for our agentic harness pipeline. think from first principles. does this replace or complement our current setup? no hard feelings about previous decisions. gimme accurate points]] | First-principles verdict: complement, not replace. Keep wiki canonical; use claude-mem only as fast cache |
 
 ## Sources (External Research)
 

--- a/vault/wiki/log.md
+++ b/vault/wiki/log.md
@@ -2,11 +2,32 @@
 type: meta
 status: active
 created: 2026-04-28
-updated: 2026-05-04
+updated: 2026-05-05
 tags: [meta, log, operations]
 ---
 
 # Wiki Operations Log
+
+## [2026-05-05] wiki-autoresearch | claude-mem over obsidian wiki as the knowledge base for our agentic harness pipeline. think from first principles. does this replace or complement our current setup? no hard feelings about previous decisions. gimme accurate points
+- Rounds: 2 (broad architecture pass + targeted evidence-gap check)
+- Sources found: 5 (existing authoritative vault sources)
+- Pages created: [[questions/Research: claude-mem over obsidian wiki as the knowledge base for our agentic harness pipeline. think from first principles. does this replace or complement our current setup? no hard feelings about previous decisions. gimme accurate points]]
+- Synthesis: [[Research: claude-mem over obsidian wiki as the knowledge base for our agentic harness pipeline. think from first principles. does this replace or complement our current setup? no hard feelings about previous decisions. gimme accurate points]]
+- Key finding: claude-mem complements wiki as fast cache. It does not replace wiki as canonical memory without new evidence for provenance, durability, and conflict-safe governance.
+
+## [2026-05-05] wiki-autoresearch | how claude-mem fits into our workflow. and whether it should replace obsidian in the codebase. no hard feelings about previous actions, rethink from first principles always
+- Rounds: 2 (broad local corpus scan + targeted gap check)
+- Sources found: 5 (from existing vault corpus)
+- Pages created: [[questions/Research: how claude-mem fits into our workflow. and whether it should replace obsidian in the codebase. no hard feelings about previous actions, rethink from first principles always]]
+- Synthesis: [[Research: how claude-mem fits into our workflow. and whether it should replace obsidian in the codebase. no hard feelings about previous actions, rethink from first principles always]]
+- Key finding: Do not replace Obsidian as canonical Layer 6 memory now. Use claude-mem, if adopted, as non-authoritative cache with mandatory wiki write-back gates.
+
+## [2026-05-05] wiki-autoresearch | claude-mem over Obsidian for Harness Layer
+- Rounds: 2 (local corpus scan + targeted gap check)
+- Sources found: 5
+- Pages created: [[questions/Research: claude-mem over Obsidian for Harness Layer]], [[concepts/memory-system-of-record-vs-ephemeral-cache]]
+- Synthesis: [[Research: claude-mem over Obsidian for Harness Layer]]
+- Key finding: Do not replace Obsidian as Layer 6 memory system-of-record. If claude-mem is introduced, use it as non-authoritative cache and keep wiki as canonical source with hook-enforced write-back.
 
 ## [2026-05-04] implement | Layer 2: grep interception + file watcher for ck
 - **ck-enforce pi extension** (`.pi/extensions/ck-enforce.ts`): Overrides lean-ctx's `grep` tool on `session_start`. Detects conceptual patterns (multi-word, no regex) and reroutes to `ck --hybrid`. Literal/exact patterns pass through to native rg. Status command: `/ck-enforce`.

--- a/vault/wiki/questions/Research: claude-mem over Obsidian for Harness Layer.md
+++ b/vault/wiki/questions/Research: claude-mem over Obsidian for Harness Layer.md
@@ -1,0 +1,71 @@
+---
+type: synthesis
+title: "Research: claude-mem over Obsidian for Harness Layer"
+created: 2026-05-05
+updated: 2026-05-05
+tags:
+  - research
+  - memory
+  - harness
+  - claude-mem
+  - obsidian
+status: developing
+related:
+  - "[[persistent-memory]]"
+  - "[[adr-009]]"
+  - "[[Research: Claude Code State-of-the-Art Harness Improvements]]"
+  - "[[lifecycle-hooks]]"
+  - "[[Codex Harness Innovations (OpenAI)]]"
+  - "[[memory-system-of-record-vs-ephemeral-cache]]"
+sources:
+  - "[[adr-009]]"
+  - "[[persistent-memory]]"
+  - "[[Research: Claude Code State-of-the-Art Harness Improvements]]"
+  - "[[claude-code-architecture-karaxai-2026]]"
+  - "[[codex-harness-innovations]]"
+---
+
+# Research: claude-mem over Obsidian for Harness Layer
+
+## Overview
+Current harness memory decision is explicit and stable: Obsidian wiki is Layer 6 system of record via ADR-009. Local corpus has no direct `claude-mem` implementation details, so replacement recommendation cannot be high confidence. Based on current evidence, full replacement is not advised; safest path is Obsidian as source of truth plus optional local auto-memory cache if needed.
+
+## Key Findings
+- **System-of-record already chosen (high)**: ADR-009 explicitly replaces vector-memory stack with claude-obsidian Mode B, with `hot.md -> index.md -> pages` retrieval and lower dependency surface (Source: [[adr-009]]).
+- **Harness contracts depend on wiki structure (high)**: Layer write/read hooks, auditability, and cross-layer memory mapping are built around `wiki/index.md`, `wiki/log.md`, and `wiki/hot.md` (Source: [[persistent-memory]]).
+- **Prompt memory is weaker than deterministic controls (high)**: Claude architecture notes ~92% instruction compliance from CLAUDE.md versus deterministic hook enforcement when configured (Source: [[lifecycle-hooks]], [[claude-code-architecture-karaxai-2026]]).
+- **Automatic memory and explicit wiki solve different problems (medium)**: Codex-style implicit memories help fast context recovery, but explicit wiki remains better for durable decisions, provenance, and human review (Source: [[codex-harness-innovations]]).
+- **No verified claude-mem data in current wiki (low)**: No local source page or benchmark for claude-mem behavior, storage model, recall quality, or failure modes in this repo context.
+
+## Key Entities
+- [[Claude Code]]: demonstrates multi-memory architecture and deterministic hook enforcement.
+- [[Codex Harness Innovations (OpenAI)]]: demonstrates automatic/implicit memory pattern.
+
+## Key Concepts
+- [[persistent-memory]]: current Layer 6 design.
+- [[lifecycle-hooks]]: reliability boundary between prompt-following and enforcement.
+- [[memory-system-of-record-vs-ephemeral-cache]]: recommended split architecture.
+
+## Contradictions
+- [[adr-009]] optimizes for explicit wiki memory with human-readable provenance; [[codex-harness-innovations]] shows value in implicit auto-memory capture. Best reconciliation: keep explicit wiki as canonical and use implicit memory only as non-authoritative accelerator.
+
+## Recommendation
+- Do **not** replace Obsidian with claude-mem as primary harness memory right now.
+- If you want claude-mem, run it as a **secondary cache layer** only:
+  - read order: claude-mem quick hints -> wiki `hot.md` -> wiki `index.md` -> linked pages
+  - write order: all accepted decisions and patterns must land in wiki files
+  - enforcement: hooks block "done" unless wiki write completed for decision-bearing tasks
+
+## Open Questions
+- What is claude-mem persistence format and durability under compaction/restart?
+- Can claude-mem expose provenance links equivalent to wiki page references?
+- What are precision/recall metrics on this repo versus wiki query flow?
+- How should conflict resolution work when claude-mem memory disagrees with wiki decisions?
+- What token/cost/latency delta appears in real harness runs with hybrid mode?
+
+## Sources
+- [[adr-009]]: persistent memory ADR, 2026-04-28.
+- [[persistent-memory]]: Layer 6 module contract.
+- [[Research: Claude Code State-of-the-Art Harness Improvements]]: memory and control architecture synthesis.
+- [[claude-code-architecture-karaxai-2026]]: CLAUDE.md memory and compliance behavior.
+- [[codex-harness-innovations]]: implicit/automatic memory pattern comparison.

--- a/vault/wiki/questions/Research: claude-mem over obsidian wiki as the knowledge base for our agentic harness pipeline. think from first principles. does this replace or complement our current setup? no hard feelings about previous decisions. gimme accurate points.md
+++ b/vault/wiki/questions/Research: claude-mem over obsidian wiki as the knowledge base for our agentic harness pipeline. think from first principles. does this replace or complement our current setup? no hard feelings about previous decisions. gimme accurate points.md
@@ -1,0 +1,80 @@
+---
+type: synthesis
+title: "Research: claude-mem over obsidian wiki as the knowledge base for our agentic harness pipeline. think from first principles. does this replace or complement our current setup? no hard feelings about previous decisions. gimme accurate points"
+created: 2026-05-05
+updated: 2026-05-05
+tags:
+  - research
+  - memory
+  - claude-mem
+  - obsidian
+  - harness
+  - first-principles
+status: developing
+related:
+  - "[[adr-009]]"
+  - "[[persistent-memory]]"
+  - "[[lifecycle-hooks]]"
+  - "[[memory-system-of-record-vs-ephemeral-cache]]"
+  - "[[Research: how claude-mem fits into our workflow. and whether it should replace obsidian in the codebase. no hard feelings about previous actions, rethink from first principles always]]"
+sources:
+  - "[[adr-009]]"
+  - "[[persistent-memory]]"
+  - "[[anthropic-effective-harnesses]]"
+  - "[[claude-code-architecture-qubytes-2026]]"
+  - "[[codex-open-source-agent-2026]]"
+---
+
+# Research: claude-mem over obsidian wiki as the knowledge base for our agentic harness pipeline. think from first principles. does this replace or complement our current setup? no hard feelings about previous decisions. gimme accurate points
+
+## Overview
+First-principles answer: `claude-mem` does not replace Obsidian wiki in current harness design. It complements wiki as a fast recall cache. Canonical decision memory, provenance, and enforcement still belong in wiki system-of-record.
+
+## Research Method
+- Round 1 (broad): evaluate harness-memory requirements, existing ADRs, and architecture contracts.
+- Round 2 (gap fill): validate whether vault contains direct `claude-mem` primary evidence.
+- Round 3: skipped; confidence ceiling reached because direct `claude-mem` source evidence is still missing.
+- Constraint note: web tool access blocked in this run, so findings rely on existing filed sources.
+
+## First-Principles Criteria
+1. Canonical memory must be durable across sessions.
+2. Memory claims must be auditable and human-inspectable.
+3. Decision provenance must be linkable and conflict-resolvable.
+4. Completion gates must enforce write-back deterministically.
+5. Fast recall is useful, but cannot override canonical truth.
+
+## Key Findings
+- **(high)** Current architecture already sets canonical memory to wiki via `[[adr-009]]`, with read order and durable files (`hot.md`, `index.md`, linked pages). (Source: [[adr-009]], [[persistent-memory]])
+- **(high)** Harness integration points and lifecycle write patterns are coupled to wiki artifacts; replacing wiki implies re-architecting memory contracts across layers. (Source: [[persistent-memory]])
+- **(high)** Deterministic hooks and gates are required for policy reliability; prompt memory alone drifts under long-running workloads. (Source: [[anthropic-effective-harnesses]], [[claude-code-architecture-qubytes-2026]])
+- **(medium)** Auto-memory pattern is useful for convenience and continuity, but strongest in non-authoritative role alongside explicit durable memory. (Source: [[codex-open-source-agent-2026]])
+- **(low)** Vault still lacks direct `claude-mem` benchmark evidence (storage semantics, provenance fidelity, recall precision, conflict behavior), so full replacement claim is unproven.
+
+## Replace vs Complement
+### Replace
+Not supported by current evidence. Fails criteria 2-4 unless additional mechanisms are proven.
+
+### Complement
+Supported. Use `claude-mem` as optional acceleration cache; keep wiki as source-of-record.
+
+## Recommended Operating Model
+1. Read path: `claude-mem` hints -> `[[hot]]` -> `[[index]]` -> canonical linked pages.
+2. Write path: all decision-bearing outputs must land in wiki first.
+3. Conflict rule: cache and wiki disagree -> wiki wins.
+4. Enforcement: stop-hook blocks completion when required wiki filing is missing.
+
+## Contradictions
+- Fast-memory systems optimize latency; wiki optimizes auditability and governance. One layer cannot optimize both without tradeoffs. Use two-layer memory model.
+
+## Open Questions
+- What are exact retention and deletion semantics for `claude-mem` in team workflows?
+- Can `claude-mem` produce source-level provenance links compatible with wikilinks?
+- What measured latency/token gain appears in this repo with cache+wiki mode?
+- What precision/recall benchmark should define acceptable cache quality?
+
+## Sources
+- [[adr-009]]: canonical memory ADR.
+- [[persistent-memory]]: layer contract and write/read patterns.
+- [[anthropic-effective-harnesses]]: long-running harness constraints.
+- [[claude-code-architecture-qubytes-2026]]: practical persistence/hook architecture notes.
+- [[codex-open-source-agent-2026]]: implicit memory as complementary pattern.

--- a/vault/wiki/questions/Research: how claude-mem fits into our workflow. and whether it should replace obsidian in the codebase. no hard feelings about previous actions, rethink from first principles always.md
+++ b/vault/wiki/questions/Research: how claude-mem fits into our workflow. and whether it should replace obsidian in the codebase. no hard feelings about previous actions, rethink from first principles always.md
@@ -1,0 +1,80 @@
+---
+type: synthesis
+title: "Research: how claude-mem fits into our workflow. and whether it should replace obsidian in the codebase. no hard feelings about previous actions, rethink from first principles always"
+created: 2026-05-05
+updated: 2026-05-05
+tags:
+  - research
+  - memory
+  - claude-mem
+  - obsidian
+  - first-principles
+status: developing
+related:
+  - "[[adr-009]]"
+  - "[[persistent-memory]]"
+  - "[[memory-system-of-record-vs-ephemeral-cache]]"
+  - "[[lifecycle-hooks]]"
+  - "[[Codex Harness Innovations (OpenAI)]]"
+  - "[[Research: claude-mem over Obsidian for Harness Layer]]"
+sources:
+  - "[[adr-009]]"
+  - "[[persistent-memory]]"
+  - "[[lifecycle-hooks]]"
+  - "[[codex-harness-innovations]]"
+  - "[[Research: claude-mem over Obsidian for Harness Layer]]"
+---
+
+# Research: how claude-mem fits into our workflow. and whether it should replace obsidian in the codebase. no hard feelings about previous actions, rethink from first principles always
+
+## Overview
+First-principles test: memory system for harness must optimize for durability, auditability, deterministic enforcement, and operator trust. Current repo already anchors these in Obsidian wiki structure and ADR-backed contracts. Result: claude-mem fits as accelerator cache, not full replacement for canonical wiki memory.
+
+## Research Method
+- Round 1 (broad): scan existing memory architecture pages, ADRs, and harness control pages in local wiki corpus.
+- Round 2 (gap-fill): check for direct claude-mem source pages, benchmark pages, and operational evidence in current vault.
+- Round 3: skipped; no new primary sources available in current corpus.
+- Constraint note: external web fetch was blocked in this run, so all conclusions are bounded to in-vault evidence.
+
+## First-Principles Requirements
+1. **Canonical truth must be inspectable by humans and agents**.
+2. **Decision provenance must be stable and linkable**.
+3. **Memory policy compliance must not depend only on model obedience**.
+4. **Fast recall layer can be lossy, canonical layer cannot be lossy**.
+
+## Key Findings
+- **(high)** Canonical memory contract already exists and is explicit: `hot.md -> index.md -> linked pages`, with append-only operations log and ADR references (Source: [[adr-009]], [[persistent-memory]]).
+- **(high)** Harness write/read points are structurally integrated with wiki pages and event hooks (`session_start`, `session_shutdown`, decision capture), so replacement would require re-architecting multiple layers (Source: [[persistent-memory]]).
+- **(high)** Deterministic hooks outperform prompt-only policy memory. Memory hints in prompts can drift; hook gates provide hard enforcement (Source: [[lifecycle-hooks]]).
+- **(medium)** Automatic memory capture patterns are useful for continuity and speed, but they complement explicit knowledge systems instead of replacing them when audit/provenance matters (Source: [[codex-harness-innovations]]).
+- **(low)** No direct claude-mem benchmark, schema, or failure-mode source is currently filed in this vault, so "replace Obsidian now" cannot be justified with high confidence (Source: [[Research: claude-mem over Obsidian for Harness Layer]]).
+
+## Decision
+Do **not** replace Obsidian as memory system-of-record in this codebase now.
+
+## Where claude-mem Fits
+- Use claude-mem as **ephemeral recall cache** for short-horizon continuity.
+- Keep wiki as **canonical memory ledger** for decisions, ADR alignment, and contradiction handling.
+- Enforce write-back: if task changes architecture/policy, completion requires wiki update.
+
+## Recommended Operating Model
+1. Read order: quick cache (claude-mem) -> `[[hot]]` -> `[[index]]` -> linked canonical pages.
+2. Write order: decision-bearing output -> wiki first; cache may mirror but never override.
+3. Conflict rule: cache vs wiki disagreement -> wiki wins.
+4. Gate rule: stop-hook blocks completion if required wiki filing is missing.
+
+## Contradictions
+- Auto-memory value is real for speed, but speed-optimized memory and audit-optimized memory have different objective functions. Treating them as one layer causes drift.
+
+## Open Questions
+- Which claude-mem storage semantics (scope, retention, deletion) are acceptable for this repo?
+- Can claude-mem emit citation/provenance pointers equivalent to wiki wikilinks?
+- What latency/token savings appear in real runs with hybrid cache + wiki write-back?
+- What is the merge/conflict policy when cache proposes stale memory against newer ADRs?
+
+## Sources
+- [[adr-009]]: canonical decision for Layer 6 memory.
+- [[persistent-memory]]: operational read/write contract.
+- [[lifecycle-hooks]]: deterministic enforcement model.
+- [[codex-harness-innovations]]: implicit memory complement pattern.
+- [[Research: claude-mem over Obsidian for Harness Layer]]: prior internal synthesis and identified gaps.


### PR DESCRIPTION
… wiki research

- Added agent-router skill for dynamic agent discovery and delegation
- Added mandatory web fetch policy: context7 for API docs, Firecrawl for all else
- Added mandatory codebase search policy: ck --hybrid default, grep only for literals
- Switched model-router from cursor/gpt-5.x to opencode-go (deepseek-v4, qwen3.6)
- Added YOLO-style local runtime to cursor-sdk-provider (all settings, sandbox off)
- Added memory system-of-record vs ephemeral cache concept to wiki
- Filed 3 claude-mem research questions; 2 autoresearch synthesis runs
- Updated wiki hot cache, index, log with latest findings
- Added argument-hint support to wiki-autoresearch prompt
- Linked .cursor/skills to agent-router skill

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the Cursor SDK local execution configuration (sandbox disabled) and normalizes tool-call arguments, which can affect tool execution behavior and safety expectations. The rest is primarily configuration/docs/wiki content changes.
> 
> **Overview**
> Introduces a new `agent-router` skill that **discovers available agents at runtime** and provides guidance for matching/delegating tasks (including parallel dispatch).
> 
> Updates agent operating policies in `.pi/SYSTEM.md` to **mandate** `context7`/Firecrawl for web fetches and prefer `ck --hybrid` over `grep` for codebase search, and tweaks the `wiki-autoresearch` prompt to accept raw `$ARGUMENTS` topics.
> 
> Switches `.pi/model-router.json` defaults from Cursor GPT-5.x models to `opencode-go` models, and updates `cursor-sdk-provider` to run with a more permissive local runtime (all settings, sandbox disabled) while **normalizing parsed tool-call arguments** for more consistent tool execution.
> 
> Adds/updates wiki pages around **memory layering (system-of-record vs cache)** and files new `claude-mem` research syntheses, with corresponding `index`/`log`/`hot` updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 971aa64c7363cbbbf36f59294f822e2f64ee76a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->