### PR TITLE
chore: bump version to 0.1.4 — bundle .pi/prompts in npm package

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -29,4 +29,4 @@ jobs:
           npm -v
 
       - name: Publish package
-        run: npm publish --provenance --access public
+        run: npm publish --provenance --access public --ignore-scripts

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ultimate-pi",
-	"version": "0.1.3",
+	"version": "0.1.4",
 	"description": "Ultimate AI coding harness for pi.dev — extensible skills, Obsidian wiki knowledge layer, compressed context, deterministic output",
 	"keywords": [
 		"pi-package",


### PR DESCRIPTION
## Changes
- Bump version from `0.1.3` → `0.1.4`
- Prompts in `.pi/prompts/` already ship with npm package (5 files):
  - `harness-setup.md` (18.4kB)
  - `git-sync.md` (3.7kB)
  - `wiki-autoresearch.md` (825B)
  - `wiki.md` (1.3kB)
  - `save.md` (743B)
- Tagged `v0.1.4`

## Publish
After merge, run `npm publish` locally (need npm auth on this machine).