### PR TITLE
feat(harness): integrate pi-vcc for deterministic auto-compaction

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,5 @@ FIRECRAWL_API_URL="http://localhost:3002"
 # FIRECRAWL_NO_TELEMETRY=0
 VAULT_WIKI_PATH="vault/wiki"
 CURSOR_API_KEY=""
+PI_VCC_CONFIG_PATH=".pi/pi-vcc-config.json"
+# VCC config: points to project-level pi-vcc config (overrideDefaultCompaction, debug)

--- a/.pi/mcp.json
+++ b/.pi/mcp.json
@@ -1,0 +1,7 @@
+{
+	"mcpServers": {
+		"context-mode": {
+			"command": "context-mode"
+		}
+	}
+}

--- a/.pi/pi-vcc-config.json
+++ b/.pi/pi-vcc-config.json
@@ -1,0 +1,4 @@
+{
+	"overrideDefaultCompaction": true,
+	"debug": false
+}

--- a/.pi/settings.json
+++ b/.pi/settings.json
@@ -10,6 +10,7 @@
 		"npm:@posthog/pi",
 		"npm:context-mode",
 		"npm:@tintinweb/pi-subagents",
-		"npm:@yeliu84/pi-model-router"
+		"npm:@yeliu84/pi-model-router",
+		"npm:@sting8k/pi-vcc"
 	]
 }

--- a/vault/wiki/concepts/vcc-conversation-compaction-for-pi.md
+++ b/vault/wiki/concepts/vcc-conversation-compaction-for-pi.md
@@ -1,7 +1,8 @@
 ---
 type: concept
-status: developing
+status: active
 created: 2026-05-05
+updated: 2026-05-07
 tags:
   - pi-agent
   - vcc
@@ -11,6 +12,7 @@ related:
   - "[[pi-vcc-github-repo]]"
   - "[[context-continuity]]"
   - "[[structured-compaction]]"
+  - "[[adr-027]]"
 ---
 
 # VCC Conversation Compaction for Pi

--- a/vault/wiki/decisions/adr-027.md
+++ b/vault/wiki/decisions/adr-027.md
@@ -1,0 +1,94 @@
+---
+type: decision
+title: "ADR-027: pi-vcc Overrides Built-in Auto-Compaction"
+status: accepted
+priority: 1
+date: "2026-05-07"
+tags: [adr, compaction, pi-vcc, vcc, context]
+sources:
+  - "[[pi-vcc-github-repo]]"
+  - "[[vcc-conversation-compaction-for-pi]]"
+  - "https://github.com/sting8k/pi-vcc/issues/3"
+related:
+  - "[[adr-012]]"
+  - "[[adr-015]]"
+created: 2026-05-07
+updated: 2026-05-07
+---
+
+# ADR-027: pi-vcc Overrides Built-in Auto-Compaction
+
+## Context
+
+Pi's default compaction uses LLM-generated summaries. This is:
+- **Non-deterministic** — can hallucinate or lose context
+- **Expensive** — burns tokens on every compaction
+- **Slow** — waits for LLM call (seconds vs milliseconds)
+- **Destructive** — pre-compaction history is permanently lost
+
+[pi-vcc](https://github.com/sting8k/pi-vcc) is an algorithmic compaction extension inspired by lllyasviel's VCC. It provides:
+- **Deterministic** — same input = same output, no LLM
+- **Zero cost** — no API calls, algorithmic extraction
+- **Fast** — 30-470ms per compaction
+- **99% token reduction** on long sessions
+- **Lossless recall** — `vcc_recall` reads raw session JSONL
+
+### Problem: Model Stops After Auto-Compaction
+
+GitHub issue [sting8k/pi-vcc#3](https://github.com/sting8k/pi-vcc/issues/3): when `overrideDefaultCompaction: true`, the AI model stops generating after auto-compaction. The maintainer confirmed it is "by design for now."
+
+**Root cause**: pi-vcc's `buildOwnCut` keeps the last user message and everything after it as the "kept tail." When that tail contains a completed turn (user message + assistant's finished response), the LLM sees a complete conversation after session reload and has no signal to continue working.
+
+## Decision
+
+### 1. Project-level pi-vcc activation (not global)
+
+pi-vcc is registered as a **project-level package** in `.pi/settings.json`, not in `~/.pi/agent/settings.json`. The config lives at `.pi/pi-vcc-config.json`, referenced via `PI_VCC_CONFIG_PATH` in `.env`.
+
+This keeps the VCC override scoped to this project only. Other projects use pi's default LLM compaction.
+
+### 2. Enable `overrideDefaultCompaction: true`
+
+All compaction paths (auto-threshold, `/compact`, `/pi-vcc`) route through pi-vcc's algorithmic compactor.
+
+### 3. Fix "model stops" with continuation directive
+
+For auto-compactions (not manual `/pi-vcc`), append `[Continue]` section to the summary:
+
+```
+[Continue]
+Continue working on the current task. The user's request is not yet complete. Use vcc_recall if you need context from earlier in the session.
+```
+
+This is patched in `node_modules/@sting8k/pi-vcc/src/hooks/before-compact.ts`, applied only when `isPiVcc === false` (auto-compact or `/compact`).
+
+## Alternatives Considered
+
+| Option | Pros | Cons |
+|--------|------|------|
+| **Keep default LLM compaction** | No risk of model stopping | Expensive, non-deterministic, slow |
+| **`overrideDefaultCompaction: false` (manual only)** | Safer, model never stops unexpectedly | User must run `/pi-vcc` manually; auto-compaction still burns LLM tokens |
+| **Fork pi-vcc repo** | Clean patch management | Overhead of maintaining fork, slow to upstream updates |
+| **Patch node_modules directly** (chosen) | Zero overhead, immediate fix | Patch lost on `npm update`; requires re-apply |
+| **Send synthetic "continue" message post-compaction** | Clean separation of concerns | Requires new `session_compact` handler; more invasive |
+| **Append continuation to summary** (chosen) | Simplest fix; minimal code change | Slightly longer summary text |
+
+## Consequences
+
+### Positive
+- **99% context reduction** on auto-compaction (vs ~70-80% with LLM)
+- **Zero compaction cost** — no LLM calls, saves tokens
+- **30-470ms latency** vs 2-10s LLM wait
+- **Deterministic output** — same session = same summary
+- **Lossless recall** via `vcc_recall` — pre-compaction history searchable
+- **Model continues working** after auto-compaction via continuation directive
+
+### Negative
+- Patch in node_modules is fragile — `npm update` removes it
+- Continuation directive may prompt unnecessary continuation if task IS actually complete (minor risk)
+- VCC config is project-scoped only — other projects don't benefit
+
+### Mitigations
+- Document the patch location so it can be re-applied after npm updates
+- Consider upstreaming the fix to pi-vcc repo
+- Continuation directive only fires on auto-compaction, not `/pi-vcc`


### PR DESCRIPTION
- Enable pi-vcc as project-level package with overrideDefaultCompaction
- Add continuation directive patch to fix model stopping after auto-compact
- Register context-mode MCP server in .pi/mcp.json
- Create ADR-027: pi-vcc overrides built-in auto-compaction
- Update VCC concept page status from developing to active