### PR TITLE
fix(ci): add --ignore-scripts to npm publish in GitHub Packages workflow

### DIFF
--- a/.github/workflows/publish-github-packages.yml
+++ b/.github/workflows/publish-github-packages.yml
@@ -30,6 +30,6 @@ jobs:
           npm pkg set publishConfig.registry='https://npm.pkg.github.com'
 
       - name: Publish package to GitHub Packages
-        run: npm publish
+        run: npm publish --ignore-scripts
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- Prevents lifecycle scripts from executing during publish to GitHub Packages
- Avoids potential side effects from postinstall/prepublish scripts