### PR TITLE
chore(release): bump to v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,76 @@
 
 All notable changes to this project are documented in this file.
 
+## [v0.2.0] — 2026-05-15
+
+### ✨ Features
+
+- update extension banner and custom header
+- add abort flow and safer live widget rendering
+- add orchestration stack and banner compatibility
+- router-aware custom footer with profile colors
+- gitignore model-router.json and generate dynamically from env
+- merge books & YT corpora, add merge scripts, up viz cap to 200K
+- add research papers and graphify knowledge graph outputs
+- add skill and rebuild knowledge graph
+- ingest Gleeson Musk first-principles prompts thread
+- add books corpus knowledge graph with cross-book linking
+- integrate ast-grep as primary code search tool
+- add sentrux architectural quality gate integration
+
+### 🐛 Fixes
+
+- consolidate outputs into graphify-out/, prevent root duplication
+- add --ignore-scripts to npm publish in GitHub Packages workflow
+
+### ♻️ Refactoring
+
+- migrate from Obsidian wiki to Graphify knowledge graph
+
+### 📖 Documentation
+
+- add beginner-friendly harness user guide
+- label all 428 communities, regenerate report and HTML
+
+### 🎨 Style
+
+- apply linter formatting (tab indent)
+
+### 🔧 Chores
+
+- refresh generated graph artifacts
+- align graphify skill source to project-local path
+- include latest post-commit graph rebuild outputs
+- refresh generated graph and harness run artifacts
+- remove redundant internal code
+- refresh generated graph artifacts
+- remove rethink agent, add youtube video catalog
+- index NEA × Namespace CI/CD / continuous compute YouTube talk
+- remove graphify-books-corpus aigleeson musk prompts markdown file
+- rename data/yt-vid to data/youtube-transcripts
+- align graphify outputs with data/books corpus paths
+- add data/ corpus: books (Git LFS) and yt-vid transcripts
+- add reusable YouTube transcript indexer (yt-dlp + Firecrawl CLI)
+- re-format includes array as multi-line
+- exclude graphify-books-out/ from lint/format
+- accept remote graphify-out artifacts, remove cache/ from tracking (gitignored)
+- add graphify-out/cache/ to .gitignore
+- update wiki docs
+- update wiki docs
+- update wiki docs
+- update wiki docs
+- update wiki docs
+- update wiki docs
+- update wiki docs
+- update wiki docs
+- update wiki docs
+- update wiki docs
+- fix biome ignore pattern: !graphify-out
+- ignore graphify-out from biome lint
+- update knowledge graph caches after background rebuild
+- remove wiki skills superseded by graphify
+- remove defuddle-cli and defuddle skill references (firecrawl covers same)
+
 ## [v0.1.7] — 2026-05-07
 
 ### ✨ Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ultimate-pi",
-	"version": "0.1.7",
+	"version": "0.2.0",
 	"description": "Ultimate AI coding harness for pi.dev — extensible skills, Obsidian wiki knowledge layer, compressed context, deterministic output",
 	"keywords": [
 		"pi-package",


### PR DESCRIPTION
## Summary
- bump package version from 0.1.7 to 0.2.0
- add changelog entry for v0.2.0 from commits since v0.1.7
- push release tag `v0.2.0` to trigger package publish workflows

## Test plan
- [x] pre-commit lint hook passes on release commit
- [x] version in `package.json` is `0.2.0`
- [x] changelog contains `v0.2.0` entry

Made with [Cursor](https://cursor.com)