### PR TITLE
fix(harness-setup): bootstrap graphify and verify CLI tools

### DIFF
--- a/.pi/prompts/graphify.md
+++ b/.pi/prompts/graphify.md
@@ -5,13 +5,9 @@ argument-hint: "[directory]"
 
 Read the `graphify` skill. Then run the setup workflow:
 
-1. Check if Graphify is installed (`pip show graphifyy`). If not, install it:
-   ```bash
-   pip install graphifyy && graphify install
-   ```
-2. Check if a graph already exists (`graphify-out/graph.json`). If yes, report
-   current graph stats (nodes, edges, communities, last built).
-3. If no graph exists, build one: `graphify ${ARGUMENTS:-.} --wiki`
+1. Check if Graphify is installed (`pip`/`pip3 show graphifyy`, `uv tool list`, or `command -v graphify`). If not, install (`uv tool install graphifyy` preferred) and `graphify install --platform pi`.
+2. Check if a valid graph exists (`graphify-out/graph.json` with ≥1 node and `GRAPH_REPORT.md`). If yes, report stats.
+3. If no valid graph, build: `GRAPHIFY_VIZ_NODE_LIMIT=200000 graphify update ${ARGUMENTS:-.}` (never `graphify . --wiki` — invalid CLI). For full semantic extraction when API keys exist: `graphify extract ${ARGUMENTS:-.}`.
 4. Read and summarize `graphify-out/GRAPH_REPORT.md` — show god nodes,
    surprising connections, and suggested questions.
 5. Tell user: "Graph built. Open `graphify-out/graph.html` for interactive
@@ -19,5 +15,5 @@ Read the `graphify` skill. Then run the setup workflow:
 
 If the graph already exists:
 - Report graph stats from `graph.json`
-- Offer to update: `graphify . --update`
+- Offer to update: `graphify update .`
 - Show recent god nodes from GRAPH_REPORT.md

--- a/.pi/prompts/harness-setup.md
+++ b/.pi/prompts/harness-setup.md
@@ -32,119 +32,52 @@ Block if node < 18, npm < 9, or git missing. Report versions and continue.
 
 Read `.pi/auto-commit.json` for co-author + branch config. Read `.pi/settings.json` for extension packages list.
 
-## Step 0.5 — Graphify Setup
+## Step 0.5 — Graphify (skip if `--skip-graphify`)
 
-Check if Graphify is installed and set up:
+**Critical:** `graphify . --wiki` and `graphify . --update` are **invalid** CLI (error: `unknown command '.'`). Use only:
 
-```bash
-# Check Python 3.10+
-python3 --version | grep -q "3\.1[0-9]" && echo "✓ Python 3.10+" || echo "✗ Need Python 3.10+"
+| Goal | Command |
+|------|---------|
+| Initial / refresh code graph (required, no LLM) | `GRAPHIFY_VIZ_NODE_LIMIT=200000 graphify update .` |
+| Full semantic graph (optional, needs API key) | `graphify extract .` |
 
-# Resolve pip (some systems expose only pip3)
-PIP_CMD=""
-command -v pip &>/dev/null && PIP_CMD=pip
-[ -z "$PIP_CMD" ] && command -v pip3 &>/dev/null && PIP_CMD=pip3
+On first `/harness-setup` in any project (including external repos), you **must** produce a valid `graphify-out/` with non-empty `graph.json` and `GRAPH_REPORT.md`. Do not ask the user whether to build — run the bootstrap script and **block** if it fails.
 
-# Check if Graphify is installed (pip/pip3, uv, apt, or on PATH)
-GRAPHIFY_INSTALLED=false
-GRAPHIFY_VIA=""
+Run from the **project root** (the external repo root, not ultimate-pi unless that is the target):
 
-if command -v graphify &>/dev/null; then
-  GRAPHIFY_INSTALLED=true
-  GRAPHIFY_VIA="path ($(command -v graphify))"
-elif [ -n "$PIP_CMD" ] && $PIP_CMD show graphifyy &>/dev/null 2>&1; then
-  GRAPHIFY_INSTALLED=true
-  GRAPHIFY_VIA="$PIP_CMD"
-elif command -v uv &>/dev/null && uv pip show graphifyy &>/dev/null 2>&1; then
-  GRAPHIFY_INSTALLED=true
-  GRAPHIFY_VIA="uv (project/venv)"
-elif command -v uv &>/dev/null && uv tool list 2>/dev/null | grep -qE '(^|[[:space:]])graphifyy([[:space:]]|$)'; then
-  GRAPHIFY_INSTALLED=true
-  GRAPHIFY_VIA="uv tool"
-elif dpkg -l 2>/dev/null | grep -qE '^ii[[:space:]]+(python3-)?graphify'; then
-  GRAPHIFY_INSTALLED=true
-  GRAPHIFY_VIA="apt (dpkg)"
-elif apt list --installed 2>/dev/null | grep -qiE '(^|/)python3?-?graphify'; then
-  GRAPHIFY_INSTALLED=true
-  GRAPHIFY_VIA="apt"
-fi
-
-if [ "$GRAPHIFY_INSTALLED" = "true" ]; then
-  echo "✓ Graphify installed via ${GRAPHIFY_VIA:-unknown}"
-else
-  echo "! Graphify not installed (checked: PATH, pip/pip3, uv, apt)"
-  GRAPHIFY_INSTALLED=false
-fi
-
-# Check if graph already exists
-test -f graphify-out/graph.json && GRAPH_EXISTS=true || GRAPH_EXISTS=false
-```
-
-**Present to user:**
-
-### Case A: Graphify installed + graph exists
-> "Graphify ready. Existing graph: `graphify-out/`. Run `graphify . --update` to refresh."
-
-### Case B: Graphify installed + no graph
-> "Graphify installed but no graph built yet. Build one now?"
-
-### Case C: Graphify not installed
-> "Graphify not found (checked PATH, `pip`/`pip3 show graphifyy`, `uv pip show` / `uv tool list`, and apt). Install with one of:
-> - `uv tool install graphifyy && graphify install` (preferred if `uv` is available)
-> - `pip install graphifyy && graphify install` (or `pip3 install graphifyy` on pip3-only systems)
-> - `sudo apt install python3-graphify` (only if your distro packages `graphifyy`; name may differ)
->
-> Install now?"
-
-### Case D: Python too old
-> "Python 3.10+ required for Graphify. Current: `$(python3 --version)`. Install Python 3.10+ before continuing."
-
-## Step 1 — Build Knowledge Graph
-
-```bash
-# Install if needed (skip if already present via pip/pip3, uv, apt, or PATH)
-if [ "$GRAPHIFY_INSTALLED" != "true" ]; then
-  PIP_CMD=""
-  command -v pip &>/dev/null && PIP_CMD=pip
-  [ -z "$PIP_CMD" ] && command -v pip3 &>/dev/null && PIP_CMD=pip3
-
-  if command -v uv &>/dev/null; then
-    uv tool install graphifyy && graphify install
-  elif [ -n "$PIP_CMD" ]; then
-    $PIP_CMD install graphifyy && graphify install
-  elif command -v apt &>/dev/null; then
-    sudo apt update && sudo apt install -y python3-graphify 2>/dev/null || {
-      echo "apt package not found — use: uv tool install graphifyy OR pip/pip3 install graphifyy"
-      exit 1
-    }
-    graphify install
-  else
-    echo "No installer found (need uv, pip/pip3, or apt). Install graphifyy manually."
-    exit 1
-  fi
-fi
-
-# Build the graph (or update existing)
-if [ "$GRAPH_EXISTS" = "true" ]; then
-  graphify . --update --wiki
-else
-  graphify . --wiki
-fi
-
-# Install git hooks — auto-update graph on commit/checkout
-graphify hook install
-
-# Quick stats
-echo "Graph built. Output: graphify-out/"
-ls graphify-out/
-```
-
-Read and summarize `graphify-out/GRAPH_REPORT.md` — show god nodes and surprising connections.
-
-Create project directories needed for graphify + harness workflow:
 ```bash
 mkdir -p ./raw .pi/harness/specs .pi/harness/runs .pi/harness/incidents .pi/harness/debates
+
+# Bundled with ultimate-pi harness; copy path if bootstrap runs from a linked harness checkout
+bash scripts/harness-graphify-bootstrap.sh
+# In ultimate-pi checkout: npm run harness:graphify-bootstrap
+# Or, if scripts/ is not present in the target repo, copy/run ultimate-pi/scripts/harness-graphify-bootstrap.sh
+
+# Pass --force when $ARGUMENTS contains --force to rebuild an existing graph:
+# bash scripts/harness-graphify-bootstrap.sh --force
 ```
+
+If `scripts/harness-graphify-bootstrap.sh` is missing in the target repo, run it from the ultimate-pi harness package path, or execute equivalent steps manually:
+
+1. Install `graphifyy` (`uv tool install` preferred; else `pip`/`pip3 install --user`)
+2. `graphify install --platform pi` (and `graphify cursor install` if `.cursor/` exists)
+3. `GRAPHIFY_VIZ_NODE_LIMIT=200000 graphify update .` — **required**; exits non-zero on failure
+4. If `GEMINI_API_KEY`, `GOOGLE_API_KEY`, `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, or `MOONSHOT_API_KEY` is set: `graphify extract .` for full semantic graph (optional enrichment)
+5. `graphify hook install` only when `.git/` exists
+6. Validate: `graphify-out/graph.json` has ≥1 node and `graphify-out/GRAPH_REPORT.md` exists
+
+**Do not continue** to Step 2+ until validation passes. Report node/edge counts from the script output.
+
+Read and summarize `graphify-out/GRAPH_REPORT.md` — god nodes and surprising connections.
+
+### Failure modes (report clearly)
+
+| Symptom | Likely cause |
+|---------|----------------|
+| `unknown command '.'` | Wrong CLI — use `graphify update .`, never `graphify .` |
+| Empty or missing `graphify-out/` | Build step skipped or failed; re-run bootstrap |
+| `graph.json` exists but 0 nodes | Stale/partial output — re-run with `--force` |
+| `graphify extract` fails | No API key — code graph from `update` is still valid; note in report |
 
 ## Step 1.5 — Optional Self-Hosted Firecrawl
 
@@ -274,9 +207,36 @@ docker compose -f firecrawl/docker-compose.yaml ps
 If user chose **cloud**, skip all 1.5.x steps. Just note:
 > "Using cloud Firecrawl. Ensure `FIRECRAWL_API_KEY` is set. Run `firecrawl login` in Step 2.1."
 
-## Step 2 — Install Global CLI Packages
+## Step 2 — Install & Verify Global CLI Tools (skip if `--skip-tools`)
 
-Check each package first. Install only if missing unless `--force` flag.
+Run the bundled verifier from the **project root**. It installs missing npm globals, fixes common **Linux system dependencies** (Chrome libs for `agent-browser`), runs smoke tests, and exits non-zero if a required tool fails.
+
+```bash
+bash scripts/harness-cli-verify.sh
+# ultimate-pi checkout: npm run harness:cli-verify
+# Reinstall everything: bash scripts/harness-cli-verify.sh --force
+```
+
+**Required (script must exit 0):** firecrawl-cli, ctx7, biome, ast-grep (`sg`), sentrux (when harness manifest present).
+
+**Warnings allowed:** gh (if not authenticated), agent-browser (if OS libs need manual `sudo apt-get install`), ck (empty corpus on tiny repos).
+
+If the script reports **agent-browser shared library errors** on Linux/WSL, run the fix it prints, then re-verify:
+
+```bash
+sudo apt-get update
+sudo apt-get install -y libnss3 libnspr4 libgbm1 libatk1.0-0 libatk-bridge2.0-0 \
+  libcups2 libdrm2 libxkbcommon0 libxcomposite1 libxdamage1 libxfixes3 libxrandr2 \
+  libasound2 libpango-1.0-0 libcairo2 libx11-6 libxcb1 libxext6 fonts-liberation
+agent-browser install --with-deps
+bash scripts/harness-cli-verify.sh
+```
+
+**Do not continue** past Step 2 if `harness-cli-verify.sh` exits non-zero.
+
+### Manual reference (if script missing in target repo)
+
+Copy `scripts/harness-cli-verify.sh` from ultimate-pi, or install tools individually:
 
 ### 2.1 — firecrawl-cli (Web Search + Scrape + Crawl + Interact + Download + Parse)
 
@@ -665,7 +625,7 @@ Created: $(date +%Y-%m-%d)
 
 ## Structure
 
-- graphify-out/ → Knowledge graph (run `graphify .` to build)
+- graphify-out/ → Knowledge graph (run `graphify update .` to build)
 - ./raw/ → Source documents for graphify ingestion
 - .pi/harness/specs/ → Harness contracts and schema docs
 - .pi/harness/incidents/ → Incident and override records
@@ -674,7 +634,7 @@ Created: $(date +%Y-%m-%d)
 
 ## Graphify-First Workflow
 
-1. Run `graphify . --wiki` to build the knowledge graph
+1. Run `graphify update .` to build/update the knowledge graph (AST, no API cost)
 2. Read `graphify-out/GRAPH_REPORT.md` for god nodes and surprising connections
 3. Query: `graphify query "question"`
 4. Harness contracts and governance records in `.pi/harness/specs/` and `.pi/harness/incidents/`
@@ -684,26 +644,22 @@ Created: $(date +%Y-%m-%d)
 - Graph before grep — always consult the knowledge graph first
 - ./raw/ is source storage for graphify
 - Decisions and incidents in `.pi/harness/` with structured artifacts
-- `graphify . --update` after significant changes
+- `GRAPHIFY_VIZ_NODE_LIMIT=200000 graphify update .` after significant code changes
 - ast-grep (`sg`) is the default code search tool — use `sg -p 'pattern'` for structural search, never grep for code
 - Create `.sg/rules/` for project-wide code quality rules
 ```
 
 ## Step 5 — Verification
 
-Run full verification suite:
+Re-run CLI verification (must pass unless `--skip-tools`):
 
 ```bash
-# CLI tools
-firecrawl --status 2>/dev/null && echo "✓ firecrawl" || echo "✗ firecrawl"
-ctx7 --help 2>/dev/null && echo "✓ ctx7" || echo "✗ ctx7"
-agent-browser --version 2>/dev/null && echo "✓ agent-browser" || echo "✗ agent-browser"
-ck --version 2>/dev/null && echo "✓ ck-search" || echo "✗ ck-search"
-biome --version 2>/dev/null && echo "✓ biome" || echo "✗ biome"
-sg --version 2>/dev/null && echo "✓ ast-grep" || echo "✗ ast-grep"
-gh --version 2>/dev/null && echo "✓ gh" || echo "✗ gh"
-sentrux --version 2>/dev/null && echo "✓ sentrux" || echo "✗ sentrux"
+bash scripts/harness-cli-verify.sh
+```
 
+Then run the remaining checks:
+
+```bash
 # pi extensions
 cd .pi/npm && npm ls 2>/dev/null && echo "✓ pi extensions" || echo "✗ pi extensions"
 
@@ -725,7 +681,15 @@ elif dpkg -l 2>/dev/null | grep -qE '^ii[[:space:]]+(python3-)?graphify' || apt 
 else
   echo "✗ graphify not installed"
 fi
-ls graphify-out/graph.json 2>/dev/null && echo "✓ knowledge graph built" || echo "✗ no graph built yet"
+python3 -c "
+import json, sys
+from pathlib import Path
+gj, gr = Path('graphify-out/graph.json'), Path('graphify-out/GRAPH_REPORT.md')
+if not gj.is_file() or not gr.is_file():
+    print('✗ knowledge graph missing (need graph.json + GRAPH_REPORT.md)'); sys.exit(0)
+n = len(json.loads(gj.read_text()).get('nodes') or [])
+print(f'✓ knowledge graph built ({n} nodes)' if n else '✗ graph.json has 0 nodes — re-run harness-graphify-bootstrap.sh --force')
+" 2>/dev/null || echo "✗ no graph built yet"
 graphify hook status 2>/dev/null && echo "✓ graphify git hooks installed" || echo "✗ graphify git hooks not installed"
 
 # model router
@@ -786,7 +750,7 @@ Output summary table:
 
 Next steps:
 1. If tools missing: re-run with `--force` or install individually
-2. If graph not built: run `graphify . --wiki`
+2. If graph not built: run `bash scripts/harness-graphify-bootstrap.sh` (or `graphify update .` from project root)
 3. If hooks not installed: run `graphify hook install`
 4. If gh not authenticated: `gh auth login`
 5. If self-hosted Firecrawl unhealthy: `docker compose -f firecrawl/docker-compose.yaml logs`
@@ -796,8 +760,10 @@ Next steps:
 ## Guard Rails
 
 - **Internet required**: Several tools need npm registry access. Block if offline.
+- **CLI verify script**: Step 2 and Step 5 use `scripts/harness-cli-verify.sh` — installs npm globals, Linux Chrome system libs for `agent-browser`, and smoke-tests each tool. Block on non-zero exit.
 - **Graphify requires Python 3.10+**: Check `python3 --version`. Block if too old.
-- **Python packages (Graphify)**: Before install, detect existing installs via `command -v graphify`, `pip` or `pip3 show graphifyy` (resolve whichever exists), `uv pip show graphifyy`, `uv tool list`, and apt (`dpkg` / `apt list`). Prefer `uv tool install` when `uv` is available; fall back to `$PIP_CMD install` (`pip` or `pip3`), then apt only if packaged.
+- **Graphify bootstrap is mandatory** (unless `--skip-graphify`): Run `scripts/harness-graphify-bootstrap.sh`. Never use `graphify . --wiki`. Initial setup must run `graphify update .` and verify `graphify-out/graph.json` has nodes.
+- **Python packages (Graphify)**: Before install, detect via PATH, `pip`/`pip3 show graphifyy`, `uv`, or apt. Prefer `uv tool install graphifyy`.
 - **Node.js >= 18 required**: Some pi packages use modern Node APIs.
 - **Docker required for self-hosted**: Step 1.5 needs Docker Engine + Compose. Block if install fails.
 - **Sufficient RAM for self-hosted**: Firecrawl stack needs ~8GB+ free (API: 8G, Playwright: 4G, others).
@@ -814,12 +780,17 @@ Next steps:
 | Node < 18 | Block. Report required version. |
 | npm not found | Block. Suggest install method per OS. |
 | Python < 3.10 | Block. Report required Python version for Graphify. |
-| Graphify install fails | Show installer output. Retry with `uv tool install graphifyy`, `pip install graphifyy` / `pip3 install graphifyy`, or distro apt package if available. Suggest `$PIP_CMD install --upgrade pip` (or `pip3 install --upgrade pip`) when using pip. |
+| CLI verify script fails | Read per-tool ✗ lines. Re-run with `--force`. Fix agent-browser libs via apt (see Step 2). |
+| agent-browser libnspr4 / shared library | `sudo apt-get install -y libnss3 libnspr4 libgbm1 ...` then `agent-browser install --with-deps`. |
+| Graphify install fails | Show installer output. Retry `uv tool install graphifyy` or `pip3 install --user graphifyy`. Ensure `~/.local/bin` is on PATH. |
+| `graphify update .` fails | Block setup. Corpus may have no code files, or graphify not on PATH. Show stderr. |
+| Invalid `graphify .` usage | Replace with `graphify update .` — the `.` subcommand does not exist. |
+| graphify-out empty / 0 nodes | Re-run `bash scripts/harness-graphify-bootstrap.sh --force` from project root. |
 | graphify hook install fails | Hooks need `.git/` directory. Verify inside git repo. Manual: `git config core.hooksPath .pi/git-hooks` |
 | firecrawl auth failed | Show manual login instructions. Continue with other tools. |
 | gh not installed | Show GitHub CLI install link. Skip label creation. |
 | pi packages install fail | Show error output. Check npm permissions. |
-| graph already exists | Report state. Offer `graphify . --update` to refresh. |
+| graph already exists | Report node count. Refresh with `graphify update .` unless user passed `--force`. |
 | biome.json missing | Create minimal config. |
 | settings.json not writable | Warn. Settings won't persist across sessions. |
 | No internet | Block for tool installs. Continue for graphify-only steps if `--skip-tools`. |
@@ -833,7 +804,7 @@ Next steps:
 
 | Flag | Effect |
 |------|--------|
-| `--skip-graphify` | Skip Step 1 (graph build). Use when graph already exists. |
+| `--skip-graphify` | Skip Step 0.5 (graph build). Only when a valid `graphify-out/graph.json` already exists. |
 | `--skip-tools` | Skip Step 2 (CLI tool installs). Use when tools already set up. |
 | `--skip-firecrawl-self` | Skip Step 1.5 (self-hosted Firecrawl). Always use cloud. |
 | `--force` | Reinstall all tools even if already present. Overwrite existing files. |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,3 +31,15 @@ Created: 2026-05-14
 - `graphify update .` after significant code changes
 - ast-grep (`sg`) is the default code search tool — use `sg -p 'pattern'` for structural search, never grep for code
 - Self-hosted Firecrawl at http://localhost:3002 (FIRECRAWL_API_URL)
+
+## graphify
+
+This project has a knowledge graph at graphify-out/ with god nodes, community structure, and cross-file relationships.
+
+When the user types `/graphify`, invoke the `skill` tool with `skill: "graphify"` before doing anything else.
+
+Rules:
+- ALWAYS read graphify-out/GRAPH_REPORT.md before reading any source files, running grep/glob searches, or answering codebase questions. The graph is your primary map of the codebase.
+- IF graphify-out/wiki/index.md EXISTS, navigate it instead of reading raw files
+- For cross-module "how does X relate to Y" questions, prefer `graphify query "<question>"`, `graphify path "<A>" "<B>"`, or `graphify explain "<concept>"` over grep — these traverse the graph's EXTRACTED + INFERRED edges instead of scanning files
+- After modifying code, run `graphify update .` to keep the graph current (AST-only, no API cost).

--- a/package.json
+++ b/package.json
@@ -36,6 +36,8 @@
 	},
 	"scripts": {
 		"check:ts": "tsc --noEmit --target ES2022 --moduleResolution nodenext --module nodenext --skipLibCheck .pi/extensions/dotenv-loader.ts .pi/extensions/lib/posthog-node.d.ts .pi/extensions/lib/harness-posthog.ts .pi/extensions/harness-telemetry.ts .pi/extensions/trace-recorder.ts .pi/extensions/observation-bus.ts .pi/extensions/drift-monitor.ts .pi/extensions/sentrux-rules-sync.ts",
+		"harness:graphify-bootstrap": "bash scripts/harness-graphify-bootstrap.sh",
+		"harness:cli-verify": "bash scripts/harness-cli-verify.sh",
 		"harness:verify": "node scripts/harness-verify.mjs",
 		"harness:sentrux-sync": "node scripts/sentrux-rules-sync.mjs --force",
 		"harness:meta-optimizer": "node .pi/harness/evolution/meta-optimizer.mjs",

--- a/scripts/harness-cli-verify.sh
+++ b/scripts/harness-cli-verify.sh
@@ -1,0 +1,294 @@
+#!/usr/bin/env bash
+# harness-cli-verify — install and smoke-test harness global CLI tools; fix common Linux deps.
+# Used by /harness-setup Step 2. Exit 0 only if all required tools pass verification.
+
+set -u
+set -o pipefail
+
+FORCE=false
+for arg in "$@"; do
+	case "$arg" in
+	--force) FORCE=true ;;
+	-h | --help)
+		echo "Usage: $0 [--force]"
+		echo "  Installs missing npm globals, fixes Linux browser libs, runs smoke tests."
+		exit 0
+		;;
+	*)
+		echo "Unknown argument: $arg" >&2
+		exit 2
+		;;
+	esac
+done
+
+export PATH="${HOME}/.local/bin:${PATH}:$(npm prefix -g 2>/dev/null)/bin"
+
+ROOT="$(pwd)"
+FAILURES=0
+WARNINGS=0
+
+log() { printf '%s\n' "$*"; }
+pass() { log "  ✓ $1"; }
+warn() { log "  ! $1"; WARNINGS=$((WARNINGS + 1)); }
+fail() { log "  ✗ $1"; FAILURES=$((FAILURES + 1)); }
+
+have_cmd() { command -v "$1" &>/dev/null; }
+
+npm_global_install() {
+	local pkg="$1"
+	if [ "$FORCE" = true ] || ! have_cmd "$2"; then
+		log "  installing $pkg..."
+		npm install -g "$pkg" || return 1
+	fi
+	return 0
+}
+
+apt_get_cmd() {
+	command -v apt-get 2>/dev/null || command -v apt 2>/dev/null || true
+}
+
+linux_apt_install() {
+	# Install apt packages when available (WSL/Debian/Ubuntu). Best-effort if sudo works.
+	local pkgs=("$@")
+	[ ${#pkgs[@]} -eq 0 ] && return 0
+	local apt_cmd
+	apt_cmd="$(apt_get_cmd)"
+	if [ -z "$apt_cmd" ]; then
+		return 2
+	fi
+	local missing=()
+	for p in "${pkgs[@]}"; do
+		dpkg -s "$p" &>/dev/null 2>&1 || missing+=("$p")
+	done
+	[ ${#missing[@]} -eq 0 ] && return 0
+	log "  installing apt packages: ${missing[*]}"
+	if sudo -n true 2>/dev/null; then
+		sudo DEBIAN_FRONTEND=noninteractive "$apt_cmd" update -qq
+		sudo DEBIAN_FRONTEND=noninteractive "$apt_cmd" install -y "${missing[@]}" || {
+			warn "apt install failed — run: sudo apt-get install -y ${missing[*]}"
+			return 1
+		}
+	else
+		return 2
+	fi
+	return 0
+}
+
+linux_pkg_install() {
+	# Debian/Ubuntu, RHEL/Fedora, or Arch — best-effort system deps for headless Chrome.
+	local pkgs_deb=(
+		libnss3 libnspr4 libatk1.0-0 libatk-bridge2.0-0 libcups2 libdrm2
+		libxkbcommon0 libxcomposite1 libxdamage1 libxfixes3 libxrandr2 libgbm1
+		libasound2 libpango-1.0-0 libcairo2 libx11-6 libxcb1 libxext6 fonts-liberation
+	)
+	if [ -n "$(apt_get_cmd)" ]; then
+		linux_apt_install "${pkgs_deb[@]}"
+		return $?
+	fi
+	if command -v dnf &>/dev/null && sudo -n true 2>/dev/null; then
+		sudo dnf install -y nss nspr atk at-spi2-atk cups-libs libdrm libxkbcommon \
+			libXcomposite libXdamage libXfixes libXrandr mesa-libgbm alsa-lib \
+			pango cairo libX11 libxcb libXext liberation-fonts 2>/dev/null && return 0
+		return 2
+	fi
+	if command -v pacman &>/dev/null && sudo -n true 2>/dev/null; then
+		sudo pacman -S --noconfirm nss nspr atk at-spi2-atk cups libdrm libxkbcommon \
+			libxcomposite libxdamage libxfixes libxrandr mesa gbm alsa-lib \
+			pango cairo libx11 libxcb libxext ttf-liberation 2>/dev/null && return 0
+		return 2
+	fi
+	return 2
+}
+
+# Playwright / agent-browser Chrome on Linux (libnspr4.so, etc.)
+ensure_linux_browser_deps() {
+	[ "$(uname -s)" != "Linux" ] && return 0
+	local rc=0
+	linux_pkg_install || rc=$?
+	if [ "$rc" -eq 2 ]; then
+		return 2
+	fi
+	return 0
+}
+
+verify_agent_browser() {
+	log "[agent-browser]"
+	npm_global_install "agent-browser" "agent-browser" || { fail "agent-browser npm install"; return; }
+
+	local deps_rc=0
+	ensure_linux_browser_deps || deps_rc=$?
+	if ! agent-browser install 2>/dev/null; then
+		warn "agent-browser install (Chrome binary) failed — may still work with system Chrome"
+	fi
+
+	local out
+	out="$(agent-browser open "about:blank" 2>&1)" || true
+	if echo "$out" | grep -qiE 'shared libraries|libnspr4|cannot open shared object'; then
+		warn "Chrome missing system libs — installing OS packages"
+		if [ "$deps_rc" -eq 2 ] || ! ensure_linux_browser_deps; then
+			warn "Could not auto-install OS packages (need sudo). Debian/Ubuntu: sudo apt-get install -y libnss3 libnspr4 libgbm1 libatk1.0-0 libx11-6"
+		fi
+		if sudo -n true 2>/dev/null; then
+			agent-browser install --with-deps 2>/dev/null || true
+		else
+			warn "Run manually: agent-browser install --with-deps"
+		fi
+		out="$(agent-browser open "about:blank" 2>&1)" || true
+	fi
+
+	if echo "$out" | grep -qiE 'shared libraries|libnspr4|Auto-launch failed'; then
+		if [ "$deps_rc" -eq 2 ]; then
+			warn "agent-browser needs Linux system libs (manual): sudo apt-get install -y libnss3 libnspr4 libgbm1 && agent-browser install --with-deps"
+		else
+			fail "agent-browser runtime failed after dep install — see stderr above"
+		fi
+	else
+		pass "agent-browser $(agent-browser --version 2>/dev/null | head -1)"
+		agent-browser close 2>/dev/null || true
+	fi
+
+	mkdir -p .pi/harness
+	if [ ! -f .pi/harness/browser.json ]; then
+		echo '{"headless": true, "timeout": 30000, "viewport": {"width": 1280, "height": 720}}' >.pi/harness/browser.json
+	fi
+}
+
+verify_firecrawl() {
+	log "[firecrawl-cli]"
+	npm_global_install "firecrawl-cli@latest" "firecrawl" || { fail "firecrawl-cli npm install"; return; }
+	if firecrawl --status &>/dev/null; then
+		pass "firecrawl $(firecrawl --status 2>/dev/null | head -1 || echo ok)"
+	else
+		fail "firecrawl --status failed (run: firecrawl login)"
+	fi
+}
+
+verify_ctx7() {
+	log "[ctx7]"
+	npm_global_install "ctx7@latest" "ctx7" || { fail "ctx7 npm install"; return; }
+	if ctx7 --help &>/dev/null; then
+		pass "ctx7"
+	else
+		fail "ctx7 --help failed"
+	fi
+}
+
+verify_ck() {
+	log "[ck-search]"
+	npm_global_install "@beaconbay/ck-search" "ck" || { fail "ck-search npm install"; return; }
+	if ! ck --version &>/dev/null; then
+		fail "ck --version failed"
+		return
+	fi
+	# Fast grep-mode smoke (no embedding model download)
+	local ck_target="."
+	[ -d .pi ] && ck_target=".pi"
+	if ck -l 1 "export" "$ck_target" 2>/dev/null | head -1 | grep -q .; then
+		pass "ck $(ck --version 2>/dev/null | head -1)"
+	elif ck --status "$ck_target" 2>/dev/null | head -1 | grep -q .; then
+		pass "ck $(ck --version 2>/dev/null | head -1) (index status ok)"
+	else
+		warn "ck installed but smoke search empty"
+	fi
+}
+
+verify_biome() {
+	log "[biome]"
+	npm_global_install "@biomejs/biome" "biome" || { fail "biome npm install"; return; }
+	if biome --version &>/dev/null; then
+		pass "biome $(biome --version 2>/dev/null | head -1)"
+	else
+		fail "biome --version failed"
+	fi
+}
+
+verify_sg() {
+	log "[ast-grep]"
+	npm_global_install "@ast-grep/cli@latest" "sg" || { fail "ast-grep npm install"; return; }
+	if ! sg --version &>/dev/null; then
+		fail "sg --version failed"
+		return
+	fi
+	if sg -p 'export' -l ts .pi 2>/dev/null | head -1 | grep -q .; then
+		pass "ast-grep $(sg --version 2>/dev/null | head -1)"
+	else
+		# Still pass if binary works
+		pass "ast-grep $(sg --version 2>/dev/null | head -1) (pattern scan skipped)"
+	fi
+}
+
+verify_gh() {
+	log "[gh]"
+	if ! have_cmd gh; then
+		if [ -n "$(apt_get_cmd)" ] && sudo -n true 2>/dev/null; then
+			log "  installing gh via apt..."
+			sudo DEBIAN_FRONTEND=noninteractive "$(apt_get_cmd)" update -qq
+			sudo DEBIAN_FRONTEND=noninteractive "$(apt_get_cmd)" install -y gh 2>/dev/null || true
+		fi
+	fi
+	if have_cmd gh && gh --version &>/dev/null; then
+		pass "gh $(gh --version 2>/dev/null | head -1)"
+		if gh auth status &>/dev/null 2>&1; then
+			pass "gh authenticated"
+			if [ -d .git ]; then
+				gh label create "harness" --color "0366d6" --description "Agentic harness managed" 2>/dev/null || true
+				gh label create "harness-spec" --color "0e8a16" --description "Hardened specification" 2>/dev/null || true
+				gh label create "harness-plan" --color "fbca04" --description "Structured plan generated" 2>/dev/null || true
+				gh label create "harness-critic" --color "d73a4a" --description "Adversarial review" 2>/dev/null || true
+			fi
+		else
+			warn "gh not authenticated (run: gh auth login)"
+		fi
+	else
+		warn "gh not installed — https://cli.github.com/ (optional for issue specs)"
+	fi
+}
+
+verify_sentrux() {
+	log "[sentrux]"
+	if ! have_cmd sentrux || [ "$FORCE" = true ]; then
+		if curl -fsSL https://raw.githubusercontent.com/sentrux/sentrux/main/install.sh | sh; then
+			export PATH="${HOME}/.local/bin:${PATH}"
+		else
+			fail "sentrux install script failed"
+			return
+		fi
+	fi
+	if ! sentrux --version &>/dev/null; then
+		fail "sentrux --version failed"
+		return
+	fi
+	sentrux plugin add-standard 2>/dev/null || warn "sentrux plugin add-standard skipped"
+	if [ -f package.json ] && grep -q harness:sentrux-sync package.json 2>/dev/null; then
+		npm run harness:sentrux-sync 2>/dev/null || warn "npm run harness:sentrux-sync failed (needs package.json scripts)"
+	fi
+	if sentrux check . &>/dev/null; then
+		pass "sentrux $(sentrux --version 2>/dev/null | head -1)"
+	else
+		warn "sentrux check . failed (rules may need manifest sync)"
+	fi
+}
+
+log "Harness CLI verification (cwd: $ROOT)"
+log ""
+
+verify_firecrawl
+verify_ctx7
+verify_agent_browser
+verify_ck
+verify_biome
+verify_sg
+verify_gh
+verify_sentrux
+
+log ""
+if [ "$FAILURES" -gt 0 ]; then
+	log "FAILED: $FAILURES required tool(s). Fix errors above and re-run."
+	exit 1
+fi
+if [ "$WARNINGS" -gt 0 ]; then
+	log "OK with $WARNINGS warning(s) (optional tools or auth)."
+else
+	log "All harness CLI tools verified."
+fi
+exit 0

--- a/scripts/harness-graphify-bootstrap.sh
+++ b/scripts/harness-graphify-bootstrap.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# harness-graphify-bootstrap — install graphify and build graphify-out for the current repo.
+# Used by /harness-setup. Do not use deprecated `graphify . --wiki` (invalid CLI).
+
+set -euo pipefail
+
+FORCE=false
+for arg in "$@"; do
+	case "$arg" in
+	--force) FORCE=true ;;
+	-h | --help)
+		echo "Usage: $0 [--force]"
+		echo "  --force   rebuild even when graphify-out/graph.json already exists"
+		exit 0
+		;;
+	*)
+		echo "Unknown argument: $arg" >&2
+		exit 2
+		;;
+	esac
+done
+
+export PATH="${HOME}/.local/bin:${PATH}"
+
+log() { printf '%s\n' "$*"; }
+die() { printf 'error: %s\n' "$*" >&2; exit 1; }
+
+# Python 3.10+
+if ! python3 --version 2>/dev/null | grep -qE 'Python 3\.(1[0-9]|[2-9][0-9])'; then
+	die "Python 3.10+ required (got: $(python3 --version 2>/dev/null || echo missing))"
+fi
+log "✓ Python 3.10+"
+
+PIP_CMD=""
+command -v pip &>/dev/null && PIP_CMD=pip
+[ -z "$PIP_CMD" ] && command -v pip3 &>/dev/null && PIP_CMD=pip3
+
+graphify_installed() {
+	command -v graphify &>/dev/null && return 0
+	[ -n "$PIP_CMD" ] && $PIP_CMD show graphifyy &>/dev/null 2>&1 && return 0
+	command -v uv &>/dev/null && uv pip show graphifyy &>/dev/null 2>&1 && return 0
+	command -v uv &>/dev/null && uv tool list 2>/dev/null | grep -qE '(^|[[:space:]])graphifyy([[:space:]]|$)' && return 0
+	dpkg -l 2>/dev/null | grep -qE '^ii[[:space:]]+(python3-)?graphify' && return 0
+	apt list --installed 2>/dev/null | grep -qiE '(^|/)python3?-?graphify' && return 0
+	return 1
+}
+
+install_graphify() {
+	if command -v uv &>/dev/null; then
+		uv tool install graphifyy
+	elif [ -n "$PIP_CMD" ]; then
+		$PIP_CMD install --user graphifyy
+	else
+		die "Need uv, pip, or pip3 to install graphifyy"
+	fi
+	export PATH="${HOME}/.local/bin:${PATH}"
+	command -v graphify &>/dev/null || die "graphify not on PATH after install (try: export PATH=\"\$HOME/.local/bin:\$PATH\")"
+}
+
+graphify_platform_install() {
+	graphify install --platform pi 2>/dev/null || graphify pi install 2>/dev/null || true
+	if [ -d .cursor ]; then
+		graphify cursor install 2>/dev/null || true
+	fi
+	if [ -f AGENTS.md ] || [ -d .pi ]; then
+		graphify codex install 2>/dev/null || true
+	fi
+}
+
+graph_is_valid() {
+	python3 - <<'PY'
+import json
+import sys
+from pathlib import Path
+
+root = Path("graphify-out")
+gj = root / "graph.json"
+gr = root / "GRAPH_REPORT.md"
+if not gj.is_file() or not gr.is_file():
+    sys.exit(1)
+data = json.loads(gj.read_text(encoding="utf-8"))
+nodes = data.get("nodes") or []
+if len(nodes) < 1:
+    sys.exit(1)
+edges = data.get("edges") or data.get("links") or []
+print(f"nodes={len(nodes)} edges={len(edges)}")
+PY
+}
+
+has_llm_key() {
+	[ -n "${GEMINI_API_KEY:-}" ] || [ -n "${GOOGLE_API_KEY:-}" ] || \
+		[ -n "${MOONSHOT_API_KEY:-}" ] || [ -n "${ANTHROPIC_API_KEY:-}" ] || \
+		[ -n "${OPENAI_API_KEY:-}" ]
+}
+
+mkdir -p graphify-out ./raw
+
+if ! graphify_installed; then
+	log "Installing graphifyy..."
+	install_graphify
+fi
+
+command -v graphify &>/dev/null || die "graphify CLI not found after install"
+log "✓ graphify ($(command -v graphify))"
+
+graphify_platform_install
+
+NEED_BUILD=true
+if [ "$FORCE" = false ] && graph_is_valid 2>/dev/null; then
+	NEED_BUILD=false
+	log "✓ Existing graphify-out/graph.json ($(graph_is_valid))"
+fi
+
+export GRAPHIFY_VIZ_NODE_LIMIT="${GRAPHIFY_VIZ_NODE_LIMIT:-200000}"
+
+if [ "$NEED_BUILD" = true ] || [ "$FORCE" = true ]; then
+	log "Building knowledge graph for codebase (graphify update .)..."
+	if ! graphify update .; then
+		die "graphify update . failed — graphify-out was not created"
+	fi
+	if ! graph_is_valid 2>/dev/null; then
+		die "graphify update . finished but graphify-out/graph.json is missing or empty"
+	fi
+	log "✓ Code graph built ($(graph_is_valid))"
+	if has_llm_key; then
+		log "LLM API key detected — running full semantic extract (graphify extract .)..."
+		if graphify extract .; then
+			if graph_is_valid 2>/dev/null; then
+				log "✓ Full graph built ($(graph_is_valid))"
+			else
+				log "! graphify extract finished but graph validation failed; code-only graph remains"
+			fi
+		else
+			log "! graphify extract failed; keeping code-only graph from graphify update ."
+		fi
+	else
+		log "No LLM API key — code-only graph (AST). Set GEMINI_API_KEY or OPENAI_API_KEY and re-run with --force for semantic extraction."
+	fi
+else
+	log "Refreshing code graph (graphify update .)..."
+	graphify update . || die "graphify update . failed"
+fi
+
+if [ -d .git ]; then
+	graphify hook install 2>/dev/null && log "✓ graphify git hooks installed" || log "! graphify hook install skipped or failed"
+else
+	log "! Not a git repo — skipped graphify hook install"
+fi
+
+log "Graph output: graphify-out/"
+ls -la graphify-out/ 2>/dev/null | head -20 || true


### PR DESCRIPTION
## Summary

- Fixes broken Graphify setup on external projects: `graphify . --wiki` is invalid CLI; new `scripts/harness-graphify-bootstrap.sh` runs `graphify update .`, validates `graphify-out/`, and optionally `graphify extract .` when API keys exist.
- Adds `scripts/harness-cli-verify.sh` to install/smoke-test harness global CLIs and fix Linux system deps for `agent-browser` (libnss3/libnspr4/etc.).
- Updates `/harness-setup` to block on both scripts and documents manual apt fallback.

## Test plan

- [ ] Run `bash scripts/harness-graphify-bootstrap.sh` on a fresh repo — expect `graphify-out/graph.json` with nodes
- [ ] Run `bash scripts/harness-cli-verify.sh` — exit 0 on Linux with apt/sudo
- [ ] Run `/harness-setup` on an external project end-to-end


Made with [Cursor](https://cursor.com)