### PR TITLE
fix(npm): unbreak pi update global install (v0.2.7)

### DIFF
--- a/.pi/PACKAGING.md
+++ b/.pi/PACKAGING.md
@@ -32,4 +32,6 @@ We use an explicit allowlist (not the whole `.pi/` tree) so dev-only artifacts n
 
 ## Dependencies
 
-Runtime pi extensions are in `dependencies` + `bundledDependencies`. `@mariozechner/pi-coding-agent` is a `peerDependency` (provided by the pi CLI).
+Runtime pi extensions are regular `dependencies` (installed by `npm install` when pi installs the package). We do **not** use `bundledDependencies`: bundling pre-installs `node_modules` and breaks `npm install -g` / `pi update` for native modules such as `koffi` (empty stub dir, postinstall fails).
+
+`@mariozechner/pi-coding-agent` is a `peerDependency` (provided by the pi CLI).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project are documented in this file.
 
+## [v0.2.7] — 2026-05-15
+
+### 🐛 Fixes
+
+- Remove `bundledDependencies` so `pi update` / `npm install -g ultimate-pi` installs a complete `koffi` tree (fixes empty `node_modules/koffi` and postinstall failure)
+- Drop `context-mode` from package `dependencies` (install via `npm:context-mode` in project settings; avoids Node &lt; 22.5 postinstall failure on global update)
+
 ## [v0.2.6] — 2026-05-15
 
 ### 🔧 Chores

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ultimate-pi",
-	"version": "0.2.6",
+	"version": "0.2.7",
 	"description": "Ultimate AI coding harness for pi.dev — extensible skills, Obsidian wiki knowledge layer, compressed context, deterministic output",
 	"keywords": [
 		"pi-package",
@@ -23,9 +23,16 @@
 		"url": "https://github.com/aryaniyaps/ultimate-pi"
 	},
 	"pi": {
-		"extensions": ["./.pi/extensions"],
-		"skills": ["./.agents/skills", "./.pi/skills"],
-		"prompts": ["./.pi/prompts"]
+		"extensions": [
+			"./.pi/extensions"
+		],
+		"skills": [
+			"./.agents/skills",
+			"./.pi/skills"
+		],
+		"prompts": [
+			"./.pi/prompts"
+		]
 	},
 	"files": [
 		".agents",
@@ -94,15 +101,7 @@
 		"@tintinweb/pi-subagents": "latest",
 		"@yeliu84/pi-model-router": "latest",
 		"asciify-image": "^0.1.10",
-		"context-mode": "latest",
 		"jimp": "^1.6.1",
 		"posthog-node": "^5.30.6"
-	},
-	"bundledDependencies": [
-		"@posthog/pi",
-		"@sting8k/pi-vcc",
-		"@tintinweb/pi-subagents",
-		"@yeliu84/pi-model-router",
-		"context-mode"
-	]
+	}
 }


### PR DESCRIPTION
## Summary

- Remove `bundledDependencies` — pre-bundled `node_modules` left an empty `koffi` directory on `npm install -g`, breaking `pi update`
- Remove `context-mode` from package `dependencies` — install via `npm:context-mode` in project settings (avoids Node < 22.5 postinstall abort on global install)

Published: `ultimate-pi@0.2.7`

## Test plan

- [x] `npm install ./ultimate-pi-0.2.7.tgz -g` completes; `koffi/src/cnoke/cnoke.js` present
- [x] `npm run harness:verify`
- [ ] `pi update` from gradient with Node 24


Made with [Cursor](https://cursor.com)