### PR TITLE
chore(release): bump to v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,17 @@ All notable changes to this project are documented in this file.
 
 ## [Unreleased]
 
+## [v0.4.1] — 2026-05-17
+
 ### ✨ Features
 
 - **In-house VCC compaction:** vendored [pi-vcc](https://github.com/sting8k/pi-vcc) (inspired by [lllyasviel/VCC](https://github.com/lllyasviel/VCC)); removed `@sting8k/pi-vcc` npm dependency. Configuration is **env-only** (`HARNESS_VCC_COMPACTION`, `HARNESS_VCC_DEBUG`) — no `PI_VCC_CONFIG_PATH` or JSON config files. VCC overrides `/compact` and auto-compaction by default; set `HARNESS_VCC_COMPACTION=false` for Pi LLM compaction. Refresh upstream: `npm run vendor:sync-vcc`.
+- **Harness subagents:** vendored harness-subagents extension with Sentrux bootstrap agent and related harness wiring.
+- **Harness web:** replace Firecrawl with Scrapling-based `harness-web` CLI for search and fetch.
+
+### 🔧 Chores
+
+- Format `.pi/settings.json` / `.pi/settings.example.json` and refresh `graphify-out` after VCC merge.
 
 ## [v0.3.1] — 2026-05-15
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ultimate-pi",
-	"version": "0.3.1",
+	"version": "0.4.1",
 	"description": "Ultimate AI coding harness for pi.dev — extensible skills, Obsidian wiki knowledge layer, compressed context, deterministic output",
 	"keywords": [
 		"pi-package",


### PR DESCRIPTION
## Summary

- Bump `package.json` to **0.4.1** and add changelog entry.
- Tag **v0.4.1** pushed to trigger publish workflows (`publish-github-packages.yml`, `publish-npm.yml`).

## Why 0.4.1

- `main` still had `0.3.1` in `package.json` after the VCC merge (version reverted during the feature PR).
- Remote tag **v0.4.0** points at a commit not on `main`'s ancestry, so **v0.4.1** is the first release tag aligned with current `main`.

## Test plan

- [ ] Merge this PR so `main` matches the tagged release commit
- [ ] Confirm GitHub Actions publish workflows succeeded for tag `v0.4.1`

Made with [Cursor](https://cursor.com)