### PR TITLE
chore(release): bump to v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project are documented in this file.
 
 ## [Unreleased]
 
+## [v0.5.0] — 2026-05-17
+
+### ✨ Features
+
+- **web_search / web_fetch pi tools:** wrap `harness-web.py` with session injection and a bash guard so agents skip `UP_PKG` and scrapling import preflights.
+- **SearXNG search backend:** pluggable `HARNESS_WEB_SEARCH_ENGINE` (`ddg_html` | `searxng`) with Docker bootstrap via `harness-searxng-bootstrap.mjs`.
+- **harness-web status:** JSON config subcommand for setup and diagnostics.
+
+### 🔧 Chores
+
+- Apply pre-commit format and refresh `graphify-out` after harness-web tools merge.
+
 ## [v0.4.1] — 2026-05-17
 
 ### ✨ Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ultimate-pi",
-	"version": "0.4.1",
+	"version": "0.5.0",
 	"description": "Ultimate AI coding harness for pi.dev — extensible skills, Obsidian wiki knowledge layer, compressed context, deterministic output",
 	"keywords": [
 		"pi-package",


### PR DESCRIPTION
## Summary
- Bump `package.json` to **0.5.0** (minor)
- Add CHANGELOG entry for harness-web `web_search` / `web_fetch` tools and SearXNG backend

## Test plan
- [x] Version and changelog only
- [ ] After merge: push tag `v0.5.0` to trigger publish workflows


Made with [Cursor](https://cursor.com)