### PR TITLE
chore(release): bump to v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project are documented in this file.
 
 ## [Unreleased]
 
+## [v0.6.0] — 2026-05-17
+
+### ✨ Features
+
+- **sentrux Pi skill:** CLI-first architectural quality workflows (`check`, `gate`, GUI) via `/skill:sentrux`; symlinked in `.pi/skills`. Pi does not load `.pi/mcp.json`.
+
+### 📖 Documentation
+
+- **harness-setup / CONTRIBUTING:** document Sentrux skill instead of MCP config; update `harness-sentrux-setup` workflow.
+
+### 🔧 Chores
+
+- Remove shipped `.pi/mcp.json` from package `files` list; refresh `graphify-out`.
+
 ## [v0.5.0] — 2026-05-17
 
 ### ✨ Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ultimate-pi",
-	"version": "0.5.0",
+	"version": "0.6.0",
 	"description": "Ultimate AI coding harness for pi.dev — extensible skills, Obsidian wiki knowledge layer, compressed context, deterministic output",
 	"keywords": [
 		"pi-package",


### PR DESCRIPTION
## Summary

Release v0.6.0 (minor): version bump and changelog for sentrux Pi skill release.

## Test plan

- [x] Changelog entry for v0.6.0
- [ ] Tag `v0.6.0` pushed after merge to trigger publish workflows


Made with [Cursor](https://cursor.com)