### PR TITLE
chore(release): bump to v0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project are documented in this file.
 
 ## [Unreleased]
 
+## [v0.6.1] — 2026-05-17
+
+### 🐛 Fixes
+
+- **SearXNG bootstrap:** generate `SEARXNG_SECRET` and set `server.secret_key` so containers no longer crash on the default `ultrasecretkey` (SearXNG 2026.4+).
+- **Harness env template:** remove obsolete `PI_VCC_CONFIG_PATH`; add env-only VCC, PostHog MCP, Sentrux, and default `VAULT_WIKI_PATH` keys aligned with `/harness-setup`.
+
 ## [v0.6.0] — 2026-05-17
 
 ### ✨ Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ultimate-pi",
-	"version": "0.6.0",
+	"version": "0.6.1",
 	"description": "Ultimate AI coding harness for pi.dev — extensible skills, Obsidian wiki knowledge layer, compressed context, deterministic output",
 	"keywords": [
 		"pi-package",


### PR DESCRIPTION
## Summary
- Patch release after harness SearXNG bootstrap and env template fixes (#135)
- Bump `package.json` to `0.6.1` and add changelog entry

## Test plan
- [x] Changelog reflects commits since `v0.6.0`
- [ ] After merge: push tag `v0.6.1` to trigger publish workflows

Made with [Cursor](https://cursor.com)