### PR TITLE
chore(release): v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project are documented in this file.
 
 ## [Unreleased]
 
+## [v0.7.0] — 2026-05-17
+
+### ✨ Features
+
+- **Harness run context:** track active run and canonical plan path in session; short slash commands without `--run` or `--plan`; project `active-run.json` for forked eval sessions; ADR 0031.
+- **System prompt extension:** load packaged `.pi/SYSTEM.md` by default with optional workspace `.pi/system.md` override.
+
+### 📖 Documentation
+
+- **README and harness prompts:** manual workflow without run IDs; `harness-run-status`, `harness-new-run`, `harness-use-run` helpers.
+
+### 🔧 Chores
+
+- **harness-setup:** remove Sentrux skill symlink step; rules bootstrap only.
+
 ## [v0.6.1] — 2026-05-17
 
 ### 🐛 Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ultimate-pi",
-	"version": "0.6.1",
+	"version": "0.7.0",
 	"description": "Ultimate AI coding harness for pi.dev — extensible skills, Obsidian wiki knowledge layer, compressed context, deterministic output",
 	"keywords": [
 		"pi-package",


### PR DESCRIPTION
## Summary

Release v0.7.0 — minor bump for harness run context and system prompt extension (merged in #137).

## Test plan

- [x] Version and CHANGELOG updated
- [ ] After merge: tag `v0.7.0` pushed to trigger publish workflows


Made with [Cursor](https://cursor.com)