### PR TITLE
chore(release): bump to v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project are documented in this file.
 
 ## [Unreleased]
 
+## [v0.8.0] — 2026-05-17
+
+### ✨ Features
+
+- **Harness command orchestration:** slash prompts spawn `harness/*` agents with required `HarnessSpawnContext`; subagent tool policy; L4 review via isolated subagents (not session fork); ADR 0032.
+
 ### 🐛 Fixes
 
 - **Policy gate / harness-plan:** allow scoped writes to `plan-packet.json` in plan phase after `ask_user` approval; block project source edits until execute; promote `/harness-auto` to execute phase mid-turn after approved plan write.
@@ -11,6 +17,10 @@ All notable changes to this project are documented in this file.
 ### 📖 Documentation
 
 - **Harness plan workflow:** present full plan → Approve via `ask_user` → persist packet; `--quick` does not skip approval (ADR 0031).
+
+### 🔧 Chores
+
+- **pi-coding-agent:** migrate peer/dev deps to `@earendil-works/pi-coding-agent` 0.74.1.
 
 ## [v0.7.0] — 2026-05-17
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ultimate-pi",
-	"version": "0.7.0",
+	"version": "0.8.0",
 	"description": "Ultimate AI coding harness for pi.dev — extensible skills, Obsidian wiki knowledge layer, compressed context, deterministic output",
 	"keywords": [
 		"pi-package",


### PR DESCRIPTION
## Summary

- Bump `package.json` to **0.8.0**
- Finalize `CHANGELOG.md` for harness command orchestration release
- Tag `v0.8.0` already pushed (triggers publish workflows)

## Test plan

- [x] Tag `v0.8.0` pushed to origin
- [ ] Merge this PR to sync `main` with release commit


Made with [Cursor](https://cursor.com)