### PR TITLE
fix(harness): correct harness-run-context import in npm package

### DIFF
--- a/.pi/extensions/lib/harness-subagents/vendored/index.ts
+++ b/.pi/extensions/lib/harness-subagents/vendored/index.ts
@@ -20,7 +20,7 @@ import { Type } from "@sinclair/typebox";
 import {
 	extractPlanApprovalsFromEntries,
 	getLatestRunContext,
-} from "../../../lib/harness-run-context.js";
+} from "../../../../lib/harness-run-context.js";
 import { getDriftReport } from "../agent-manifest.js";
 import { Blackboard } from "../blackboard.js";
 import {

--- a/.pi/harness/agents.manifest.json
+++ b/.pi/harness/agents.manifest.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "1.0.0",
   "package": "ultimate-pi",
-  "package_version": "0.8.0",
-  "generated_at": "2026-05-17T09:55:45.240Z",
+  "package_version": "0.9.0",
+  "generated_at": "2026-05-17T10:06:28.388Z",
   "agents": {
     "pi-pi/agent-expert": {
       "path": ".pi/agents/pi-pi/agent-expert.md",

--- a/.pi/scripts/harness-verify.mjs
+++ b/.pi/scripts/harness-verify.mjs
@@ -5,7 +5,7 @@
 
 import { readFile, access } from "node:fs/promises";
 import { constants } from "node:fs";
-import { join, dirname } from "node:path";
+import { join, dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { spawn } from "node:child_process";
 
@@ -201,6 +201,33 @@ async function main() {
 	const runCtxLib = join(ROOT, ".pi", "lib", "harness-run-context.ts");
 	if (!(await fileExists(runCtxLib))) fail("missing lib/harness-run-context.ts");
 	ok("lib/harness-run-context.ts");
+
+	const vendoredIndex = join(
+		ROOT,
+		".pi",
+		"extensions",
+		"lib",
+		"harness-subagents",
+		"vendored",
+		"index.ts",
+	);
+	const vendoredSrc = await readFile(vendoredIndex, "utf-8");
+	const runCtxImport = vendoredSrc.match(
+		/from ["']([^"']*harness-run-context\.js)["']/,
+	);
+	if (!runCtxImport) {
+		fail("vendored/index.ts must import harness-run-context.js");
+	}
+	const runCtxImportPath = resolve(
+		dirname(vendoredIndex),
+		runCtxImport[1].replace(/\.js$/, ".ts"),
+	);
+	if (runCtxImportPath !== runCtxLib) {
+		fail(
+			`vendored/index.ts harness-run-context import resolves to ${runCtxImportPath}, expected ${runCtxLib}`,
+		);
+	}
+	ok("vendored/index.ts harness-run-context import path");
 
 	const policyGateSrc = await readFile(
 		join(ROOT, ".pi", "extensions", "policy-gate.ts"),

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
 		"format": "biome format --write",
 		"format:check": "biome format",
 		"prepare": "lefthook install",
-		"test": "node --test test/harness-verify.test.mjs test/harness-ask-user.test.mjs test/harness-subagents-loader.test.mjs test/sentrux-rules-sync.test.mjs test/harness-budget-guard.test.mjs && npx -y tsx --test test/harness-vcc-settings.test.ts test/harness-plan-phase-policy.test.mjs test/harness-subagent-policy.test.mjs test/harness-turn-routing.test.mjs",
+		"test": "node --test test/harness-verify.test.mjs test/harness-ask-user.test.mjs test/harness-subagents-loader.test.mjs test/harness-subagents-import-path.test.mjs test/sentrux-rules-sync.test.mjs test/harness-budget-guard.test.mjs && npx -y tsx --test test/harness-vcc-settings.test.ts test/harness-plan-phase-policy.test.mjs test/harness-subagent-policy.test.mjs test/harness-turn-routing.test.mjs",
 		"test:vcc": "npx -y tsx --test vendor/pi-vcc/tests/*.test.ts",
 		"harness:sentrux-bootstrap": "node .pi/scripts/harness-sentrux-bootstrap.mjs",
 		"harness:sentrux-sync": "node .pi/scripts/sentrux-rules-sync.mjs --force",

--- a/test/harness-subagents-import-path.test.mjs
+++ b/test/harness-subagents-import-path.test.mjs
@@ -1,0 +1,19 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { existsSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const vendoredIndex = join(
+	root,
+	".pi/extensions/lib/harness-subagents/vendored/index.ts",
+);
+const runCtxLib = join(root, ".pi/lib/harness-run-context.ts");
+
+test("vendored harness-subagents resolves harness-run-context from package lib/", () => {
+	const rel = "../../../../lib/harness-run-context.js";
+	const resolved = resolve(dirname(vendoredIndex), rel.replace(/\.js$/, ".ts"));
+	assert.equal(resolved, runCtxLib);
+	assert.ok(existsSync(resolved), `missing ${resolved}`);
+});


### PR DESCRIPTION
## Summary
- Fix `vendored/index.ts` import path: `../../../../lib/harness-run-context.js` (was `../../../lib`, resolving under `extensions/lib` and breaking npm installs)
- Add harness-verify guard and `harness-subagents-import-path.test.mjs`
- Sync `agents.manifest.json` package_version to 0.9.0

## Test plan
- [x] `node .pi/scripts/harness-verify.mjs`
- [x] `npm test`

Made with [Cursor](https://cursor.com)