### PR TITLE
chore(release): bump to v0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project are documented in this file.
 
 ## [Unreleased]
 
+## [v0.9.1] — 2026-05-17
+
+### 🐛 Fixes
+
+- **npm package:** fix `harness-subagents` vendored import of `harness-run-context` (`../../../../lib`); broken installs failed with `Cannot find module '../../../lib/harness-run-context.js'`.
+
 ## [v0.9.0] — 2026-05-17
 
 ### ✨ Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ultimate-pi",
-	"version": "0.9.0",
+	"version": "0.9.1",
 	"description": "Ultimate AI coding harness for pi.dev — extensible skills, Obsidian wiki knowledge layer, compressed context, deterministic output",
 	"keywords": [
 		"pi-package",


### PR DESCRIPTION
## Summary
Patch release for harness-subagents import path fix (npm installs).

Tag `v0.9.1` will be pushed after merge.

Made with [Cursor](https://cursor.com)