### PR TITLE
chore(release): bump to v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project are documented in this file.
 
 ## [Unreleased]
 
+## [v0.10.0] — 2026-05-17
+
+### ✨ Features
+
+- **Harness plan UX:** scrollable `approve_plan` overlay with `harness-plan-draft` parent transcript; planner-only `create_plan` persists canonical `plan-packet.json` after approval; blocks planner `write`/`edit` for plan files; syncs subagent approvals and dedupes duplicate plan-approval gates.
+
 ## [v0.9.1] — 2026-05-17
 
 ### 🐛 Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ultimate-pi",
-	"version": "0.9.1",
+	"version": "0.10.0",
 	"description": "Ultimate AI coding harness for pi.dev — extensible skills, Obsidian wiki knowledge layer, compressed context, deterministic output",
 	"keywords": [
 		"pi-package",


### PR DESCRIPTION
## Summary

Release commit for v0.10.0 (changelog + package.json version). Tag `v0.10.0` is already pushed to trigger publish workflows.

## Test plan

- [x] Version and CHANGELOG updated locally
- [ ] Merge to sync `main` with release commit


Made with [Cursor](https://cursor.com)