### PR TITLE
chore(release): bump to v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project are documented in this file.
 
 ## [Unreleased]
 
+## [v0.11.0] — 2026-05-17
+
+### ✨ Features
+
+- **Harness Darwin plan pipeline:** decomposition and hypothesis agents with plan-adversary, scouts, and structured plan brief schemas (ADR 0034).
+- **Harness plan review:** `plan-review.md` for editor review; extension load guard.
+- **Cursor Pi experts:** cursor-pi domain expert agents.
+
+### 🔄 CI/CD
+
+- **Biome:** ignore harness runtime JSON; format committed harness plan pipeline sources.
+
 ## [v0.10.1] — 2026-05-17
 
 ### 🐛 Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ultimate-pi",
-	"version": "0.10.1",
+	"version": "0.11.0",
 	"description": "Ultimate AI coding harness for pi.dev — extensible skills, Obsidian wiki knowledge layer, compressed context, deterministic output",
 	"keywords": [
 		"pi-package",


### PR DESCRIPTION
## Summary
- Bump package.json to 0.11.0
- Add CHANGELOG entry for Darwin harness plan pipeline release

Tag `v0.11.0` already pushed to origin.

## Test plan
- [x] npm run lint

Made with [Cursor](https://cursor.com)