### PR TITLE
chore(release): bump to v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project are documented in this file.
 
 ## [Unreleased]
 
+## [v0.12.0] — 2026-05-18
+
+### ✨ Features
+
+- **Harness subagents:** vendor `pi-subagents`; spawn budget, precheck, and policy bridge.
+- **Router spawn auth:** forward concrete provider/model + API key to subprocesses using `--no-extensions` (fixes planning scout 401 with `router/auto`).
+- **Plan review gate:** debate orchestration, execution-plan schemas, `write_harness_yaml`, plan-phase smoke fixture (ADR 0035).
+
+### 🔧 Chores
+
+- Stop tracking harness runtime and local graphify artifacts in git.
+
 ## [v0.11.0] — 2026-05-17
 
 ### ✨ Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ultimate-pi",
-	"version": "0.11.0",
+	"version": "0.12.0",
 	"description": "Ultimate AI coding harness for pi.dev — extensible skills, Obsidian wiki knowledge layer, compressed context, deterministic output",
 	"keywords": [
 		"pi-package",


### PR DESCRIPTION
## Summary

Release v0.12.0: version bump and changelog for harness subagent auth, vendored pi-subagents, and plan review gate (merged in #151).

Tag `v0.12.0` is already pushed and should trigger publish workflows.

## Test plan

- [x] Version and changelog only


Made with [Cursor](https://cursor.com)