### PR TITLE
chore(release): bump to v0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project are documented in this file.
 
 ## [Unreleased]
 
+## [v0.14.0] — 2026-05-18
+
+### ✨ Features
+
+- **Plan debate (pi-messenger):** `harness_debate_open`, `harness_messenger_post`, lane auto-apply after subagent returns, consensus gates on `approve_plan`, and blocks on parent `review-round-r*.yaml` writes.
+- **Spawn budget:** remove harness subagent spawn cap (spawns always allowed).
+- **Skills:** symlink `.pi/skills/*` to `.agents/skills` (harness, ccc, scrapling-web, wiki-save).
+
+### 🔧 Chores
+
+- Refresh planning agent prompts and `agents.manifest.json`; biome unused-import cleanup.
+
 ## [v0.13.1] — 2026-05-18
 
 ### 🔧 Chores

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ultimate-pi",
-	"version": "0.13.1",
+	"version": "0.14.0",
 	"description": "Ultimate AI coding harness for pi.dev — extensible skills, Obsidian wiki knowledge layer, compressed context, deterministic output",
 	"keywords": [
 		"pi-package",


### PR DESCRIPTION
## Summary

Release v0.14.0 (minor): plan debate messenger pipeline shipped in #154.

## Test plan

- [x] Version bump and CHANGELOG only


Made with [Cursor](https://cursor.com)