### PR TITLE
chore(release): bump to v0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project are documented in this file.
 
 ## [Unreleased]
 
+## [v0.15.0] — 2026-05-19
+
+### ✨ Features
+
+- **Live widget:** Single-row footer with current/next pipeline phase and plain-language status hints; removes inFlight, policy jargon, and flag rows.
+- **Plan phase:** Implementation researcher, selective debate lanes/eligibility, planning rubrics, ADR 0036, and smoke fixture updates.
+
+### ✅ Tests
+
+- Add `harness-live-widget-status` and `plan-debate-eligibility` tests.
+
 ## [v0.14.0] — 2026-05-18
 
 ### ✨ Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ultimate-pi",
-	"version": "0.14.0",
+	"version": "0.15.0",
 	"description": "Ultimate AI coding harness for pi.dev — extensible skills, Obsidian wiki knowledge layer, compressed context, deterministic output",
 	"keywords": [
 		"pi-package",


### PR DESCRIPTION
## Summary

Release v0.15.0 (minor) after #157 — harness live widget simplification and plan-phase debate extensions.

## Test plan

- [x] Changelog and `package.json` version only


Made with [Cursor](https://cursor.com)