### PR TITLE
chore(release): v0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project are documented in this file.
 
 ## [Unreleased]
 
+## [v0.17.0] — 2026-05-22
+
+### ✨ Features
+
+- **Model router:** Session-locked model SKU at start (initial prompt + system prompt); per-turn routing adjusts thinking tier only; subagents lock from agent `systemPrompt` complexity.
+- **Harness:** Thinking-only profile shape in generator/verify; plan review gate, debate eligibility, and smoke fixture updates.
+
+### ✅ Tests
+
+- Add `harness-model-router-routing` and plan-debate eligibility coverage.
+
 ## [v0.16.0] — 2026-05-19
 
 ### ✨ Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ultimate-pi",
-	"version": "0.16.0",
+	"version": "0.17.0",
 	"description": "Ultimate AI coding harness for pi.dev — extensible skills, Obsidian wiki knowledge layer, compressed context, deterministic output",
 	"keywords": [
 		"pi-package",


### PR DESCRIPTION
## Summary
- Bump package version to **0.17.0** (minor; session-locked model router feat in #163).
- Update `CHANGELOG.md` for v0.17.0.

## Test plan
- [x] Version/changelog only
- [ ] After merge: tag `v0.17.0` and push tag to trigger publish workflows


Made with [Cursor](https://cursor.com)