### PR TITLE
chore(release): bump to v0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project are documented in this file.
 
 ## [Unreleased]
 
+## [v0.18.0] — 2026-05-23
+
+### ✨ Features
+
+- **Harness:** Agent-native plan/review workflows (ADR 0042–0044) — path-first `approve_plan` / `create_plan` / `submit_*`, lakes on execution plans, `parallel_probes` debate, `review-outcome.yaml` routing, `/harness-steer` repair loop, `merge_harness_yaml`, and `harness_synthesize_repair_brief`.
+- **Harness:** Practice map, planning-context and plan-synthesizer agents, PostHog bootstrap, graphify KB updater corpus, and Sentrux steward prompt.
+
+### ✅ Tests
+
+- Add harness tool-payload, post-run routing, subprocess bootstrap, artifact gate, and topology tests; extend smoke plan fixture for parallel probes.
+
 ## [v0.17.0] — 2026-05-22
 
 ### ✨ Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ultimate-pi",
-	"version": "0.17.0",
+	"version": "0.18.0",
 	"description": "Ultimate AI coding harness for pi.dev — extensible skills, Obsidian wiki knowledge layer, compressed context, deterministic output",
 	"keywords": [
 		"pi-package",


### PR DESCRIPTION
## Summary

Release v0.18.0 after merging agent-native harness workflows (#165).

## Test plan

- [x] Changelog and version bump only
- [ ] CI publish workflows on tag push after merge


Made with [Cursor](https://cursor.com)