### PR TITLE
chore(release): bump to v0.18.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,7 @@ graphify-books-out/.graphify_root
 
 # Harness runtime (per-developer; specs/, docs/adrs/, evals/smoke/ stay committed)
 .pi/harness/active-run.json
+.pi/harness/project.json
 .pi/harness/release-readiness-report.md
 .pi/harness/plans/
 .pi/harness/critics/

--- a/.pi/harness/project.json
+++ b/.pi/harness/project.json
@@ -1,5 +1,0 @@
-{
-	"schema_version": "1.0.0",
-	"enabled": true,
-	"updated_at": "2026-05-23T19:41:54.797Z"
-}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ All notable changes to this project are documented in this file.
 
 - **Graphify KB updater:** Productize conservative daily discovery/promotion with explicit repo/release taxonomy, allowlist source-class gates, operator review queue reporting, scheduler smoke validation, and safe Graphify refresh controls.
 
+## [v0.18.1] — 2026-05-24
+
+### 🔧 Chores
+
+- Ignore local project runtime config.
+- Fix harness review revise flow and widget UX.
+- Add harness project toggle controls.
+
 ## [v0.18.0] — 2026-05-23
 
 ### ✨ Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ultimate-pi",
-	"version": "0.18.0",
+	"version": "0.18.1",
 	"description": "Ultimate AI coding harness for pi.dev — extensible skills, Obsidian wiki knowledge layer, compressed context, deterministic output",
 	"keywords": [
 		"pi-package",


### PR DESCRIPTION
Release v0.18.1.\n\nChanges:\n- Ignore  as local harness runtime config.\n- Bump package version to .\n- Add changelog entry for .\n\nTag  has already been pushed to trigger publish workflows.