### PR TITLE
chore(release): bump to v0.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ All notable changes to this project are documented in this file.
 - **Harness lens:** Integrate selected pi-lens capabilities through a harness-owned extension, store lens state under `.pi/harness/.lens`, and route lens findings through harness PostHog telemetry instead of standalone lens health/telemetry surfaces.
 - **Graphify KB updater:** Productize conservative daily discovery/promotion with explicit repo/release taxonomy, allowlist source-class gates, operator review queue reporting, scheduler smoke validation, and safe Graphify refresh controls.
 
+## [v0.19.0] — 2026-05-24
+
+### ✨ Features
+
+- **Harness:** `agents.policy.yaml` as per-agent tool SSOT with manifest alignment; subprocess `subagent-governance` bundle and AGT `tool_allowed` enforcement.
+- **Harness:** Consolidate shared modules under `.pi/lib/` (moved from `.pi/extensions/lib/`); update imports, packaging, verify, and tests.
+- **Harness:** AGT-backed policy gate with subprocess governance bundle (extends v0.18.x AGT work).
+
+### 🔧 Chores
+
+- Apply Biome organize-imports and format fixes across moved harness library files.
+- Commit pending harness architecture and context tooling updates.
+
 ## [v0.18.1] — 2026-05-24
 
 ### 🔧 Chores

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ultimate-pi",
-	"version": "0.18.1",
+	"version": "0.19.0",
 	"description": "Ultimate AI coding harness for pi.dev — extensible skills, Obsidian wiki knowledge layer, compressed context, deterministic output",
 	"keywords": [
 		"pi-package",


### PR DESCRIPTION
## Summary
Release v0.19.0 — version bump and changelog for agents.policy.yaml SSOT, `.pi/lib` consolidation, and AGT policy gate work merged in #174.

## Test plan
- [x] Changelog and `package.json` version only


Made with [Cursor](https://cursor.com)