### PR TITLE
chore(release): bump to v0.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ All notable changes to this project are documented in this file.
 - **Harness lens:** Integrate selected pi-lens capabilities through a harness-owned extension, store lens state under `.pi/harness/.lens`, and route lens findings through harness PostHog telemetry instead of standalone lens health/telemetry surfaces.
 - **Graphify KB updater:** Productize conservative daily discovery/promotion with explicit repo/release taxonomy, allowlist source-class gates, operator review queue reporting, scheduler smoke validation, and safe Graphify refresh controls.
 
+## [v0.21.0] — 2026-05-26
+
+### ✨ Features
+
+- **Harness:** Add ls-lint filename fitness (manifest, sync, steward agent, harness-verify) and plan-phase task clarification gate before execution.
+
+### 🔧 Chores
+
+- Add `agents-policy.d.mts` and hash-anchored edit typecheck fixes so `npm run check:ts` passes on main.
+
 ## [v0.20.0] — 2026-05-26
 
 ### ✨ Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ultimate-pi",
-	"version": "0.20.0",
+	"version": "0.21.0",
 	"description": "Ultimate AI coding harness for pi.dev — extensible skills, Obsidian wiki knowledge layer, compressed context, deterministic output",
 	"keywords": [
 		"pi-package",


### PR DESCRIPTION
## Summary

Release housekeeping for v0.21.0 (tag `v0.21.0` already pushed to trigger publish workflows).

- Bump `package.json` to 0.21.0
- Add CHANGELOG entry for ls-lint naming fitness and plan task clarification gate

## Test plan

- [x] Tag `v0.21.0` pushed to origin


Made with [Cursor](https://cursor.com)