### PR TITLE
chore(release): bump to v0.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to this project are documented in this file.
 
+## [v0.22.0] — 2026-05-27
+
+### ✨ Features
+
+- OSS Sentrux structured repair without Pro or MCP
+
+### 📖 Documentation
+
+- split repo docs by audience
+
+### 🔧 Chores
+
+- apply pending harness and ask-user updates
+- remove obsolete PostHog plan latency dashboard doc
+
 ## [Unreleased]
 
 ### ✨ Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ultimate-pi",
-	"version": "0.21.0",
+	"version": "0.22.0",
 	"description": "Ultimate AI coding harness for pi.dev — extensible skills, Obsidian wiki knowledge layer, compressed context, deterministic output",
 	"keywords": [
 		"pi-package",


### PR DESCRIPTION
## Summary
- bump package.json version to v0.22.0
- add CHANGELOG.md entry for v0.22.0
- release tag v0.22.0 already pushed to trigger publish workflows