### PR TITLE
chore(release): bump to v0.22.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project are documented in this file.
 
+## [v0.22.2] — 2026-05-28
+
+### 🐛 Fixes
+
+- Harden harness plan/run/review/auto pipeline routing: reconcile run context from disk and handoffs, sync review-outcome from eval, fix harness-auto fresh runs (plan path, abort lock, kill-switch disarm), add harness-clear and expanded tests.
+
 ## [v0.22.1] — 2026-05-27
 
 ### 🔧 Chores

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ultimate-pi",
-	"version": "0.22.1",
+	"version": "0.22.2",
 	"description": "Governed AI coding harness for pi.dev — bootstrap, plan, execute, review, and steer with deterministic policy gates",
 	"keywords": [
 		"pi-package",


### PR DESCRIPTION
## Summary
- Bump `package.json` to **0.22.2**
- Add CHANGELOG entry for harness pipeline routing fixes (PR #189)

Tag `v0.22.2` is already pushed to trigger publish workflows.

## Test plan
- [x] Version and changelog only


Made with [Cursor](https://cursor.com)