### PR TITLE
chore(release): bump to v0.23.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project are documented in this file.
 
+
+## [v0.23.0] — 2026-05-28
+
+### ✨ Features
+
+- strengthen run context human gates
+
 ## [v0.22.2] — 2026-05-28
 
 ### 🐛 Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ultimate-pi",
-	"version": "0.22.2",
+	"version": "0.23.0",
 	"description": "Governed AI coding harness for pi.dev — bootstrap, plan, execute, review, and steer with deterministic policy gates",
 	"keywords": [
 		"pi-package",


### PR DESCRIPTION
## Summary
- Bump package.json to v0.23.0
- Add CHANGELOG.md entry for v0.23.0

## Release
- Tag v0.23.0 has already been pushed and triggered publish workflows.
