### PR TITLE
chore(release): bump to v0.24.0

### DIFF
--- a/.pi/harness/agents.manifest.json
+++ b/.pi/harness/agents.manifest.json
@@ -1,7 +1,7 @@
 {
 	"schema_version": "1.0.0",
 	"package": "ultimate-pi",
-	"package_version": "0.23.0",
+	"package_version": "0.24.0",
 	"generated_at": "2026-05-27T15:57:32.501Z",
 	"policy_sha256": "1a631333f1abed3b411961d3527bcae2d4fcd2f715b09a689b0b83b3ea0f54f3",
 	"agents": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project are documented in this file.
 
 
+## [v0.24.0] — 2026-06-06
+
+### ✨ Features
+
+- Cut harness workflow latency with phase-aware subagent timeouts, debate wall-clock caps, ccc index debounce, optional parallel review spawns, progress UI with stall detection, and PostHog phase telemetry.
+
 ## [v0.23.0] — 2026-05-28
 
 ### ✨ Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ultimate-pi",
-	"version": "0.23.0",
+	"version": "0.24.0",
 	"description": "Governed AI coding harness for pi.dev — bootstrap, plan, execute, review, and steer with deterministic policy gates",
 	"keywords": [
 		"pi-package",


### PR DESCRIPTION
## Summary

- Bump `package.json` and `agents.manifest.json` to v0.24.0
- Add changelog entry for harness workflow latency fixes (merged via #193)

Tag `v0.24.0` is already pushed to trigger publish workflows.

## Test plan

- [x] Version bump committed locally
- [x] Tag `v0.24.0` pushed to origin


Made with [Cursor](https://cursor.com)