### PR TITLE
chore(release): bump to v0.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to this project are documented in this file.
 
 
+## [v0.25.0] — 2026-06-07
+
+### ✨ Features
+
+- Wire agent-native speed program: `parallel_probes` end-to-end, eligibility snapshot, plan FSM (`harness_plan_next_action`), synthesizer routing, auto-approve policy, per-phase spawn caps, review parallel default, 50% VCC auto-compact, ADR 0056.
+
+### 🐛 Fixes
+
+- Headless QA E2E: seed planning-context for smoke auto-approve, finalize plan on `agent_end`, write smoke ISO for `/harness-auto`, and exit via `ctx.abort()` without kill-switch false failures.
+
 ## [v0.24.0] — 2026-06-06
 
 ### ✨ Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ultimate-pi",
-	"version": "0.24.0",
+	"version": "0.25.0",
 	"description": "Governed AI coding harness for pi.dev — bootstrap, plan, execute, review, and steer with deterministic policy gates",
 	"keywords": [
 		"pi-package",


### PR DESCRIPTION
## Summary

- Bump `package.json` to **0.25.0**
- Add changelog for agent-native speed wiring and headless QA E2E fixes (merged in #195)

## Test plan

- [x] Version string updated
- [x] CHANGELOG entry added


Made with [Cursor](https://cursor.com)