### PR TITLE
chore(release): bump to v0.26.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project are documented in this file.
 
 
+## [v0.26.0] — 2026-06-07
+
+### ✨ Features
+
+- Git workflow automation and steer/review hardening: auto feature branches from protected refs, scoped commits with `--only-path`, headless QA git finalize with `git-workflow.yaml`, hygiene fast-path steer, lite review preflight, inline repair, and ADR 0057 fast steer completion.
+
 ## [v0.25.0] — 2026-06-07
 
 ### ✨ Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ultimate-pi",
-	"version": "0.25.0",
+	"version": "0.26.0",
 	"description": "Governed AI coding harness for pi.dev — bootstrap, plan, execute, review, and steer with deterministic policy gates",
 	"keywords": [
 		"pi-package",


### PR DESCRIPTION
## Summary
- Bump `package.json` to **0.26.0** (minor)
- Add CHANGELOG entry for harness git workflow + steer/review hardening (PR #197)

## Test plan
- [x] Version/changelog only — no code changes beyond release metadata


Made with [Cursor](https://cursor.com)